### PR TITLE
Add new method for removing by ref

### DIFF
--- a/data/data_test.go
+++ b/data/data_test.go
@@ -364,8 +364,7 @@ func TestData_DelFeed(t *testing.T) {
 	})
 }
 
-func testRootError(t *testing.T, re *RootError, rp *RootPack,
-	pk cipher.PubKey) {
+func testRootError(t *testing.T, re *RootError, rp *RootPack,	pk cipher.PubKey) {
 
 	if re.Hash() != rp.Hash {
 		t.Error("wrong root hash of RootError")

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -364,7 +364,8 @@ func TestData_DelFeed(t *testing.T) {
 	})
 }
 
-func testRootError(t *testing.T, re *RootError, rp *RootPack,	pk cipher.PubKey) {
+func testRootError(t *testing.T, re *RootError, rp *RootPack,
+	pk cipher.PubKey) {
 
 	if re.Hash() != rp.Hash {
 		t.Error("wrong root hash of RootError")


### PR DESCRIPTION
Also fixed tests (replaced container with registry)
`PASS ok  	github.com/skycoin/cxo/node	110.829s`
But now every test have this: 
```
HERE ~/.skycoin/cxo/client
22:07:01 conn.go:350: [ERR] [::]:8998 reading error: EOF
22:07:01 conn.go:427: [ERR] [::]:8998 writing error: write tcp [::1]:49831->[::1]:8998: use of closed network connection
22:07:01 conn.go:350: [ERR] [::]:8998 reading error: read tcp [::1]:49837->[::1]:8998: use of closed network connection
```

Might be related to my fix for container for registry replacement?