### PR TITLE
node test, data/stat->data, node fixes of Subscribe and Unsubscribe of Client

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher"
 
-	dstat "github.com/skycoin/cxo/data/stat"
+	"github.com/skycoin/cxo/data"
 	"github.com/skycoin/cxo/node"
 )
 
@@ -397,7 +397,7 @@ func feeds(rpc *node.RPCClient) (err error) {
 }
 
 func stat(rpc *node.RPCClient) (err error) {
-	var stat dstat.Stat
+	var stat data.Stat
 	if stat, err = rpc.Stat(); err != nil {
 		return
 	}

--- a/data/data.go
+++ b/data/data.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/skycoin/skycoin/src/cipher"
-
-	"github.com/skycoin/cxo/data/stat"
 )
 
 // ErrRootAlreadyExists oocurs when you try to save root object
@@ -72,7 +70,7 @@ type DB interface {
 	//
 
 	// Stat of the DB
-	Stat() (s stat.Stat)
+	Stat() (s Stat)
 	// Close the DB
 	Close() (err error)
 }
@@ -98,10 +96,6 @@ type RootError struct {
 	hash  cipher.SHA256 // hash of root
 	seq   uint64        // seq of root
 	descr string        // description
-}
-
-func shortHex(a string) string {
-	return string([]byte(a)[:7])
 }
 
 // Error implements error interface

--- a/data/drive.go
+++ b/data/drive.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
-
-	"github.com/skycoin/cxo/data/stat"
 )
 
 const dbMode = 0644
@@ -393,7 +391,7 @@ func (d *driveDB) DelRootsBefore(pk cipher.PubKey, seq uint64) {
 	})
 }
 
-func (d *driveDB) Stat() (s stat.Stat) {
+func (d *driveDB) Stat() (s Stat) {
 	// Objects int
 	// Space   Space
 	// Feeds   map[cipher.PubKey]struct {
@@ -405,7 +403,7 @@ func (d *driveDB) Stat() (s stat.Stat) {
 		o := t.Bucket(objectsBucket)
 		s.Objects = o.Stats().KeyN
 		e := o.ForEach(func(_, val []byte) (_ error) {
-			s.Space += stat.Space(len(val))
+			s.Space += Space(len(val))
 			return
 		})
 		if e != nil {
@@ -417,13 +415,13 @@ func (d *driveDB) Stat() (s stat.Stat) {
 		if feeds := f.Stats().KeyN; feeds == 0 {
 			return // no feeds
 		} else {
-			s.Feeds = make(map[cipher.PubKey]stat.FeedStat, feeds)
+			s.Feeds = make(map[cipher.PubKey]FeedStat, feeds)
 		}
 		var pk cipher.PubKey
 		// for each feed
 		e = f.ForEach(func(pkb, _ []byte) (_ error) {
 			// pkb is bucket name
-			var fs stat.FeedStat
+			var fs FeedStat
 
 			fpk := f.Bucket(pkb)
 			fs.Roots = fpk.Stats().KeyN
@@ -431,7 +429,7 @@ func (d *driveDB) Stat() (s stat.Stat) {
 			// for each seq->hash
 			e := fpk.ForEach(func(_, hashb []byte) (_ error) {
 				// size of encoded RootPack
-				fs.Space += stat.Space(len(r.Get(hashb)))
+				fs.Space += Space(len(r.Get(hashb)))
 				return
 			})
 			if e != nil {

--- a/data/memory.go
+++ b/data/memory.go
@@ -5,8 +5,6 @@ import (
 	"sync"
 
 	"github.com/skycoin/skycoin/src/cipher"
-
-	"github.com/skycoin/cxo/data/stat"
 )
 
 // buckets:
@@ -281,25 +279,25 @@ func (d *memoryDB) DelRootsBefore(pk cipher.PubKey, seq uint64) {
 	}
 }
 
-func (d *memoryDB) Stat() (s stat.Stat) {
+func (d *memoryDB) Stat() (s Stat) {
 	d.mx.RLock()
 	defer d.mx.RUnlock()
 
 	s.Objects = len(d.objects)
 	for _, v := range d.objects {
-		s.Space += stat.Space(len(v))
+		s.Space += Space(len(v))
 	}
 
 	if len(d.feeds) == 0 {
 		return
 	}
-	s.Feeds = make(map[cipher.PubKey]stat.FeedStat, len(d.feeds))
+	s.Feeds = make(map[cipher.PubKey]FeedStat, len(d.feeds))
 	// lengths of Prev, Hash, Sig and Seq (8 byte)
 	var add int = len(cipher.SHA256{})*2 + len(cipher.Sig{}) + 8
 	for pk, rs := range d.feeds {
-		var fs stat.FeedStat
+		var fs FeedStat
 		for _, hash := range rs {
-			fs.Space += stat.Space(len(d.roots[hash].Root) + add)
+			fs.Space += Space(len(d.roots[hash].Root) + add)
 		}
 		fs.Roots = len(rs)
 		s.Feeds[pk] = fs

--- a/data/stat.go
+++ b/data/stat.go
@@ -1,9 +1,4 @@
-// Package stat represents statistic of a database.
-// The package introduced to use it inside packages
-// (such as 'cli') that doesn't need full functionality
-// of the cxo/data package. Thus the package avoids
-// unnessesary import dependencies (like boltdb)
-package stat
+package data
 
 import (
 	"fmt"

--- a/node/client_test.go
+++ b/node/client_test.go
@@ -70,7 +70,11 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestClient_Start(t *testing.T) {
-	// Start(address string) (err error) {
+	// Start(address string) (err error)
+
+	// 1. invalid address
+	// 2. valid address
+
 	t.Run("invalid address", func(t *testing.T) {
 		c, err := newClient(nil)
 		if err != nil {
@@ -81,6 +85,7 @@ func TestClient_Start(t *testing.T) {
 			t.Error("mising error")
 		}
 	})
+
 	t.Run("connect", func(t *testing.T) {
 		s, err := newRunninServer(nil)
 		if err != nil {
@@ -99,7 +104,7 @@ func TestClient_Start(t *testing.T) {
 }
 
 func TestClient_Close(t *testing.T) {
-	// Close() (err error) {
+	// Close() (err error)
 
 	// TODO: low priority
 }
@@ -111,7 +116,7 @@ func TestClient_IsConnected(t *testing.T) {
 }
 
 func TestClient_Subscribe(t *testing.T) {
-	// Subscribe(feed cipher.PubKey) (ok bool) {
+	// Subscribe(feed cipher.PubKey) (ok bool)
 
 	pk, sk := cipher.GenerateKeyPair()
 
@@ -202,7 +207,7 @@ func TestClient_Subscribe(t *testing.T) {
 }
 
 func TestClient_Unsubscribe(t *testing.T) {
-	// Unsubscribe(feed cipher.PubKey, del bool) (ok bool) {
+	// Unsubscribe(feed cipher.PubKey, del bool) (ok bool)
 
 	pk, sk := cipher.GenerateKeyPair()
 
@@ -303,11 +308,41 @@ func TestClient_Unsubscribe(t *testing.T) {
 }
 
 func TestClient_Feeds(t *testing.T) {
-	// Feeds() (feeds []cipher.PubKey) {
+	// Feeds() (feeds []cipher.PubKey)
+
+	f1, _ := cipher.GenerateKeyPair()
+	f2, _ := cipher.GenerateKeyPair()
+
+	c, err := newClient(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if c.Feeds() != nil {
+		t.Error("non nil for empty list of feeds")
+	}
+
+	c.Subscribe(f1)
+	if feeds := c.Feeds(); len(feeds) != 1 {
+		t.Error("unexpected amount of feeds subscribed to")
+	} else if feeds[0] != f1 {
+		t.Error("wrong feed")
+	}
+
+	c.Subscribe(f2)
+	if feeds := c.Feeds(); len(feeds) != 2 {
+		t.Error("unexpected amount of feeds subscribed to")
+	} else {
+		if !((feeds[0] == f1 && feeds[1] == f2) ||
+			(feeds[1] == f1 && feeds[0] == f2)) {
+			t.Error("wrong feeds")
+		}
+	}
 
 }
 
 func TestClient_Container(t *testing.T) {
-	// Container() *Container {
+	// Container() *Container
 
 }

--- a/node/client_test.go
+++ b/node/client_test.go
@@ -345,4 +345,5 @@ func TestClient_Feeds(t *testing.T) {
 func TestClient_Container(t *testing.T) {
 	// Container() *Container
 
+	// TODO: low priority
 }

--- a/node/client_test.go
+++ b/node/client_test.go
@@ -4,6 +4,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/cxo/skyobject"
 )
 
 func TestNewClient(t *testing.T) {
@@ -66,56 +71,138 @@ func TestNewClient(t *testing.T) {
 
 func TestClient_Start(t *testing.T) {
 	// Start(address string) (err error) {
-
+	t.Run("invalid address", func(t *testing.T) {
+		c, err := newClient(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer c.Close()
+		if err = c.Start("domain dot tld"); err == nil {
+			t.Error("mising error")
+		}
+	})
+	t.Run("connect", func(t *testing.T) {
+		s, err := newRunninServer(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+		c, err := newClient(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer c.Close()
+		if err = c.Start(s.pool.Address()); err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestClient_Close(t *testing.T) {
 	// Close() (err error) {
 
+	// TODO: low priority
 }
 
 func TestClient_IsConnected(t *testing.T) {
-	// IsConnected() bool {
+	// IsConnected() bool
 
-}
-
-func TestClient_setIsConnected(t *testing.T) {
-	// setIsConnected(t bool) {
-
-}
-
-func TestClient_connectHandler(t *testing.T) {
-	// connectHandler(cn *gnet.Conn) {
-
-}
-
-func TestClient_disconnectHandler(t *testing.T) {
-	// disconnectHandler(cn *gnet.Conn) {
-
-}
-
-func TestClient_handle(t *testing.T) {
-	// handle(cn *gnet.Conn) {
-
-}
-
-func TestClient_handlePingMsg(t *testing.T) {
-	// handlePingMsg() {
-
-}
-
-func TestClient_sendMessage(t *testing.T) {
-	// sendMessage(msg Msg) (ok bool) {
-
+	// TODO: low priority
 }
 
 func TestClient_Subscribe(t *testing.T) {
 	// Subscribe(feed cipher.PubKey) (ok bool) {
 
+	pk, sk := cipher.GenerateKeyPair()
+
+	// 1. sending AddFeed
+	// 2. sending last full root
+	// 3. already subscribed
+
+	t.Run("AddFeed sending", func(t *testing.T) {
+		conf := newClientConfig()
+		c, s, err := newRunningClient(conf, nil, []cipher.PubKey{pk})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+		defer c.Close()
+		if !c.Subscribe(pk) {
+			t.Fatal("can't subscribe")
+		}
+
+		time.Sleep(TM) // sleep....
+
+		s.fmx.Lock()
+		defer s.fmx.Unlock()
+		if cs, ok := s.feeds[pk]; !ok {
+			t.Error("misisng or slow")
+		} else {
+			if len(cs) != 1 {
+				t.Error("misisng or slow")
+			}
+		}
+
+	})
+
+	t.Run("last full sending", func(t *testing.T) {
+
+		type User struct{ Name string }
+
+		reg := skyobject.NewRegistry()
+		reg.Register("User", User{})
+
+		c, err := newClient(reg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer c.Close()
+
+		s, err := newRunninServer([]cipher.PubKey{pk})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+
+		root, err := c.so.NewRoot(pk, sk)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, _, err := root.Inject("User", User{"Alice"}); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := c.Start(s.pool.Address()); err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep(TM) // sleep....
+
+		if s.so.LastFullRoot(pk) == nil {
+			t.Error("misisng or slow")
+		}
+
+	})
+
+	t.Run("already subscribed", func(t *testing.T) {
+		c, err := newClient(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer c.Close()
+
+		if !c.Subscribe(pk) {
+			t.Error("can't subscribe")
+		} else if c.Subscribe(pk) {
+			t.Error("subscribed twice")
+		}
+	})
+
 }
 
 func TestClient_Unsubscribe(t *testing.T) {
-	// Unsubscribe(feed cipher.PubKey) (ok bool) {
+	// Unsubscribe(feed cipher.PubKey, del bool) (ok bool) {
 
 }
 

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -78,12 +78,7 @@ func newServer() (s *Server, err error) {
 	return
 }
 
-// start server and connect given client to the server
-// returning the server you need to close later. The server
-// subscribed to given list of feeds, but client doesn't
-// and some time required to sync between client and server.
-// To handle the syncing use ClientConfig.OnAddFeed callback
-func startClient(c *Client, feeds []cipher.PubKey) (s *Server, err error) {
+func newRunninServer(feeds []cipher.PubKey) (s *Server, err error) {
 	s, err = newServer()
 	if err != nil {
 		return
@@ -94,6 +89,18 @@ func startClient(c *Client, feeds []cipher.PubKey) (s *Server, err error) {
 	}
 	for _, f := range feeds {
 		s.AddFeed(f)
+	}
+	return
+}
+
+// start server and connect given client to the server
+// returning the server you need to close later. The server
+// subscribed to given list of feeds, but client doesn't
+// and some time required to sync between client and server.
+// To handle the syncing use ClientConfig.OnAddFeed callback
+func startClient(c *Client, feeds []cipher.PubKey) (s *Server, err error) {
+	if s, err = newRunninServer(feeds); err != nil {
+		return
 	}
 	if err = c.Start(s.pool.Address()); err != nil {
 		s.Close()

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -25,6 +25,12 @@ func clean() {
 	os.RemoveAll(testDataDir)
 }
 
+func shouldPanic(t *testing.T) {
+	if recover() == nil {
+		t.Error("missing panic")
+	}
+}
+
 func newClientConfig() (conf ClientConfig) {
 	conf = NewClientConfig()
 	conf.Log.Debug = testing.Verbose()
@@ -67,8 +73,13 @@ func newServerConfig() (conf ServerConfig) {
 //     s.pool.Address()
 //
 // after Start
-func newServer() (s *Server, err error) {
-	s, err = NewServer(newServerConfig())
+func newServer() (*Server, error) {
+	return newServerConf(newServerConfig())
+}
+
+// newServerConf like newServer, but it uses provided config
+func newServerConf(conf ServerConfig) (s *Server, err error) {
+	s, err = NewServer(conf)
 	if err != nil {
 		return
 	}

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/skycoin/skycoin/src/cipher"
 
-	"github.com/skycoin/cxo/data/stat"
+	"github.com/skycoin/cxo/data"
 )
 
 // A RPC is receiver type for net/rpc.
@@ -99,7 +99,7 @@ func (r *RPC) Feeds(_ struct{}, list *[]cipher.PubKey) (_ error) {
 	return
 }
 
-func (r *RPC) Stat(_ struct{}, stat *stat.Stat) (_ error) {
+func (r *RPC) Stat(_ struct{}, stat *data.Stat) (_ error) {
 	*stat = r.ns.Stat()
 	return
 }

--- a/node/rpc_client.go
+++ b/node/rpc_client.go
@@ -3,7 +3,7 @@ package node
 import (
 	"net/rpc"
 
-	"github.com/skycoin/cxo/data/stat"
+	"github.com/skycoin/cxo/data"
 	"github.com/skycoin/skycoin/src/cipher"
 )
 
@@ -46,7 +46,7 @@ func (r *RPCClient) Feeds() (list []cipher.PubKey, err error) {
 	return
 }
 
-func (r *RPCClient) Stat() (stat stat.Stat, err error) {
+func (r *RPCClient) Stat() (stat data.Stat, err error) {
 	r.c.Call("cxo.Stat", struct{}{}, &stat)
 	return
 }

--- a/node/server.go
+++ b/node/server.go
@@ -8,7 +8,6 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 
 	"github.com/skycoin/cxo/data"
-	"github.com/skycoin/cxo/data/stat"
 	"github.com/skycoin/cxo/skyobject"
 
 	"github.com/skycoin/cxo/node/gnet"
@@ -764,7 +763,7 @@ func (s *Server) Feeds() (fs []cipher.PubKey) {
 }
 
 // Stat returns satatistic of database
-func (s *Server) Stat() stat.Stat {
+func (s *Server) Stat() data.Stat {
 	return s.db.Stat()
 }
 

--- a/node/server.go
+++ b/node/server.go
@@ -192,11 +192,13 @@ func (s *Server) Start() (err error) {
 
 		s.conf.Log.Debug,
 	)
+
 	// start listener
 	if err = s.pool.Listen(s.conf.Listen); err != nil {
 		return
 	}
 	s.Print("listen on ", s.pool.Address())
+
 	// start rpc listener if need
 	if s.conf.EnableRPC == true {
 		if err = s.rpc.Start(s.conf.RPCAddress); err != nil {

--- a/node/server_test.go
+++ b/node/server_test.go
@@ -169,83 +169,83 @@ func TestServer_Start(t *testing.T) {
 func TestServer_Close(t *testing.T) {
 	// Close() (err error)
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Connect(t *testing.T) {
 	// Connect(address string) (err error)
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Disconnect(t *testing.T) {
 	// Disconnect(address string) (err error)
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Connections(t *testing.T) {
 	// Connections() []*gnet.Conn
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Connection(t *testing.T) {
 	// Connection(address string) *gnet.Conn
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_AddFeed(t *testing.T) {
 	// AddFeed(f cipher.PubKey) (added bool)
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_DelFeed(t *testing.T) {
 	// DelFeed(f cipher.PubKey) (deleted bool)
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Want(t *testing.T) {
 	// Want(feed cipher.PubKey) (wn []cipher.SHA256)
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Got(t *testing.T) {
 	// Got(feed cipher.PubKey) (gt []cipher.SHA256)
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Feeds(t *testing.T) {
 	// Feeds() (fs []cipher.PubKey)
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Stat(t *testing.T) {
 	// Stat() stat.Stat
 
-	//
+	// TODO: mid. priority
 
 }
 
 func TestServer_Quiting(t *testing.T) {
 	// Quiting() <-chan struct{}
 
-	//
+	// TODO: mid. priority
 
 }

--- a/node/server_test.go
+++ b/node/server_test.go
@@ -1,0 +1,188 @@
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewServer(t *testing.T) {
+	// NewServer(sc ServerConfig) (s *Server, err error)
+
+	// 1. memory db
+	// 2. data dir
+	// 3. database path
+
+	defer clean()
+
+	t.Run("memory db", func(t *testing.T) {
+		clean()
+
+		conf := newServerConfig() // in-memory
+
+		s, err := NewServer(conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+
+		if _, err := os.Stat(conf.DataDir); err == nil {
+			t.Error("unexpected data dir:", conf.DataDir)
+			if _, err = os.Stat(conf.DBPath); err == nil {
+				t.Error("unexpected db file:", conf.DBPath)
+			} else if !os.IsNotExist(err) {
+				t.Error("unexpected error")
+			}
+		} else if !os.IsNotExist(err) {
+			t.Error("unexpected error:", err)
+		}
+
+	})
+
+	t.Run("data dir", func(t *testing.T) {
+		clean()
+
+		conf := newServerConfig()
+		conf.InMemoryDB = false
+
+		s, err := NewServer(conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+
+		if _, err := os.Stat(conf.DataDir); err != nil {
+			t.Error(err)
+		} else {
+			if _, err := os.Stat(conf.DBPath); err != nil {
+				t.Error(err)
+			}
+		}
+
+	})
+
+	t.Run("dbpath", func(t *testing.T) {
+		clean()
+
+		conf := newServerConfig()
+		conf.InMemoryDB = false
+		conf.DBPath = filepath.Join(testDataDir, "another.db")
+
+		s, err := NewServer(conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+
+		if _, err := os.Stat(conf.DataDir); err != nil {
+			t.Error(err)
+		} else {
+			if _, err := os.Stat(conf.DBPath); err != nil {
+				t.Error(err)
+			}
+		}
+
+	})
+
+}
+
+func TestNewServerSoDB(t *testing.T) {
+	// NewServerSoDB(sc ServerConfig, db data.DB,
+	//     so *skyobject.Container) (s *Server, err error)
+
+	// 1. db != nil
+	// 2. so != nil
+	// 3. invalig gnet.Config
+
+}
+
+func TestServer_Start(t *testing.T) {
+	// Start() (err error)
+
+	//
+
+}
+
+func TestServer_Close(t *testing.T) {
+	// Close() (err error)
+
+	//
+
+}
+
+func TestServer_Connect(t *testing.T) {
+	// Connect(address string) (err error)
+
+	//
+
+}
+
+func TestServer_Disconnect(t *testing.T) {
+	// Disconnect(address string) (err error)
+
+	//
+
+}
+
+func TestServer_Connections(t *testing.T) {
+	// Connections() []*gnet.Conn
+
+	//
+
+}
+
+func TestServer_Connection(t *testing.T) {
+	// Connection(address string) *gnet.Conn
+
+	//
+
+}
+
+func TestServer_AddFeed(t *testing.T) {
+	// AddFeed(f cipher.PubKey) (added bool)
+
+	//
+
+}
+
+func TestServer_DelFeed(t *testing.T) {
+	// DelFeed(f cipher.PubKey) (deleted bool)
+
+	//
+
+}
+
+func TestServer_Want(t *testing.T) {
+	// Want(feed cipher.PubKey) (wn []cipher.SHA256)
+
+	//
+
+}
+
+func TestServer_Got(t *testing.T) {
+	// Got(feed cipher.PubKey) (gt []cipher.SHA256)
+
+	//
+
+}
+
+func TestServer_Feeds(t *testing.T) {
+	// Feeds() (fs []cipher.PubKey)
+
+	//
+
+}
+
+func TestServer_Stat(t *testing.T) {
+	// Stat() stat.Stat
+
+	//
+
+}
+
+func TestServer_Quiting(t *testing.T) {
+	// Quiting() <-chan struct{}
+
+	//
+
+}


### PR DESCRIPTION
1. Misbehavior of `node.Client` `Subscribe` and `Unsubscribe` methods
  + `node.Client.Subscribe` returns false only if the `Client` already subscribed to given feed
  + `node.Client.Unsubscribe` returns false only if the `Client` is not subscribed to given feed
  + the `Unsubscribe` method accepts two arguments to allow delete or preserve root objects of feed

2. Tests for `node.Client` and `node.Server`

3. Package `data/stat` merged with `data`.