### PR TITLE
cmd/cxocli implement 'tree' command and related

### DIFF
--- a/cmd/cxocli/CHANGELOG.md
+++ b/cmd/cxocli/CHANGELOG.md
@@ -3,9 +3,19 @@ changes
 
 ##### TODO
 
-- [ ] change subscribe_to from optimistic to based on subscribeResponse
 - [ ] add a command to see connection->feeds
 - [ ] add a command to see feed->connections
-- [ ] implement Tree method
-- [ ] suppress stdout output for tests (low)
 - [ ] implement all tests
+
+### Done
+
+####  1:00 16 June 2017 UTC
+
+- [x] change subscribe_to from optimistic to based on `SubscribeResponse`
+- [x] implement `tree` command
+- [x] suppress stdout output for tests
+
+Also
+
++ added `roots` command to see brief information about all roots of a feed
++ some tests

--- a/cmd/cxocli/CHANGELOG.md
+++ b/cmd/cxocli/CHANGELOG.md
@@ -1,0 +1,11 @@
+changes
+=======
+
+##### TODO
+
+- [ ] change subscribe_to from optimistic to based on subscribeResponse
+- [ ] add a command to see connection->feeds
+- [ ] add a command to see feed->connections
+- [ ] implement Tree method
+- [ ] suppress stdout output for tests (low)
+- [ ] implement all tests

--- a/cmd/cxocli/README.md
+++ b/cmd/cxocli/README.md
@@ -2,10 +2,3 @@ CLI
 ===
 
 The CLI is used to control and explore CXO daemon
-
-##### TODO
-
-- [ ] change subscribe_to from optimistic to based on subscribeResponse
-- [ ] add a command to see connection->feeds
-- [ ] add a command to see feed->connections
-- [ ] implement method

--- a/cmd/cxocli/cxocli_test.go
+++ b/cmd/cxocli/cxocli_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/cxo/node"
+	"github.com/skycoin/cxo/skyobject"
+)
+
+const (
+	TM time.Duration = 100 * time.Millisecond
+)
+
+type User struct {
+	Name string
+	Age  uint32
+}
+
+type Group struct {
+	Name  string
+	Users skyobject.References `skyobject:"schema=User"`
+}
+
+var testOut *bytes.Buffer = new(bytes.Buffer)
+
+func init() {
+	out = testOut // owerwrite
+	if !testing.Verbose() {
+		log.SetOutput(ioutil.Discard)
+	}
+}
+
+func Test_want(t *testing.T) {
+	// want(rpc, ss)
+
+	// TODO: low priority
+}
+
+func Test_got(t *testing.T) {
+	// got(rpc, ss)
+
+	// TODO: low priority
+}
+
+func Test_subscribe(t *testing.T) {
+	// subscribe(rpc, ss)
+
+	//
+}
+
+func Test_subscribe_to(t *testing.T) {
+	// subscribe_to(rpc, ss)
+
+	//
+}
+
+func Test_unsubscribe(t *testing.T) {
+	// unsubscribe(rpc, ss)
+
+	//
+}
+
+func Test_unsubscribe_from(t *testing.T) {
+	// unsubscribe_from(rpc, ss)
+
+	//
+}
+
+func Test_feeds(t *testing.T) {
+	// feeds(rpc)
+
+	//
+}
+
+func Test_stat(t *testing.T) {
+	// stat(rpc)
+
+	//
+}
+
+func Test_connections(t *testing.T) {
+	// connections(rpc)
+
+	//
+}
+
+func Test_incoming_connections(t *testing.T) {
+	// incoming_connections(rpc)
+
+	//
+}
+
+func Test_outgoing_connections(t *testing.T) {
+	// outgoing_connections(rpc)
+
+	//
+}
+
+func Test_connect(t *testing.T) {
+	// connect(rpc, ss)
+
+	//
+}
+
+func Test_disconnect(t *testing.T) {
+	// disconnect(rpc, ss)
+
+	//
+}
+
+func Test_listening_address(t *testing.T) {
+	// listening_address(rpc)
+
+	//
+}
+
+func Test_roots(t *testing.T) {
+	// roots(rpc, ss)
+
+	t.Run("empty feed", func(t *testing.T) {
+		defer testOut.Reset()
+
+		n, err := launchNode(newNodeConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer n.Close()
+
+		cl, err := node.NewRPCClient(n.RPCAddress())
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		pk, _ := cipher.GenerateKeyPair()
+
+		err = roots(cl, []string{
+			"roots",
+			pk.Hex(),
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if testOut.String() != "  empty feed\n" {
+			t.Errorf("wrong output %q", testOut.String())
+		}
+	})
+
+	t.Run("two", func(t *testing.T) {
+		defer testOut.Reset()
+
+		n, err := launchNode(newNodeConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer n.Close()
+
+		cl, err := node.NewRPCClient(n.RPCAddress())
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		pk, sk := cipher.GenerateKeyPair()
+
+		n.Subscribe(nil, pk)
+
+		root, err := n.Container().NewRoot(pk, sk)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		// 1
+		if _, err = root.Touch(); err != nil {
+			t.Error(err)
+			return
+		}
+		h1 := root.Hash()
+		t1 := time.Unix(0, root.Time())
+		// 2
+		if _, err = root.Touch(); err != nil {
+			t.Error(err)
+			return
+		}
+		h2 := root.Hash()
+		t2 := time.Unix(0, root.Time())
+
+		err = roots(cl, []string{
+			"roots",
+			pk.Hex(),
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		const format = `  - %s
+      time: %s
+      seq: 0
+      fill: true
+  - %s
+      time: %s
+      seq: 1
+      fill: true
+`
+
+		// for windows
+		out := strings.Replace(testOut.String(), "\r\n", "\n", -1)
+		want := fmt.Sprintf(format,
+			h1.String(),
+			t1.String(),
+			h2.String(),
+			t2.String())
+
+		if out != want {
+			t.Error("wrong output")
+		}
+
+	})
+}
+
+func Test_tree(t *testing.T) {
+	// tree(rpc, ss)
+
+	defer testOut.Reset()
+
+	n, err := launchNode(newNodeConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer n.Close()
+
+	cl, err := node.NewRPCClient(n.RPCAddress())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	pk, sk := cipher.GenerateKeyPair()
+
+	n.Subscribe(nil, pk)
+
+	root, err := n.Container().NewRoot(pk, sk)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	root.Inject("Group", Group{
+		Name: "Just an average Group",
+		Users: root.SaveArray(
+			User{
+				Name: "Bob Simple",
+				Age:  40,
+			},
+			User{
+				Name: "Jim Cobley",
+				Age:  80,
+			},
+		),
+	})
+
+	hash := root.Hash()
+
+	err = tree(cl, []string{
+		"roots",
+		hash.String(),
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	const want = `(root) %s
+└── struct Group
+    ├── (field) Name
+    │   └── Just an average Group
+    └── (field) Users
+        └── []User
+            ├── *(static) ff1eaf416e8281b398693ce5934af57482493622e4e2978c751e8b12542f04cb
+            │   └── struct User
+            │       ├── (field) Name
+            │       │   └── Bob Simple
+            │       └── (field) Age
+            │           └── 40
+            └── *(static) 915fbaac74e9a55c9ed7050a829d117d8734d0444e3543b8d67557ed9ae813bc
+                └── struct User
+                    ├── (field) Name
+                    │   └── Jim Cobley
+                    └── (field) Age
+                        └── 80
+
+`
+
+	// for windows
+	out := strings.Replace(testOut.String(), "\r\n", "\n", -1)
+
+	if out != fmt.Sprintf(want, hash.String()) {
+		t.Error("wrong output")
+	}
+}
+
+func Test_term(t *testing.T) {
+	// term(rpc)
+
+	t.Run("allowed", func(t *testing.T) {
+		defer testOut.Reset()
+
+		conf := newNodeConfig()
+		conf.RemoteClose = true
+
+		n, err := launchNode(conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer n.Close()
+
+		cl, err := node.NewRPCClient(n.RPCAddress())
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if err := term(cl); err != nil {
+			t.Error(err)
+			return
+		}
+
+		select {
+		case <-n.Quiting():
+			if testOut.String() != "  terminated\n" {
+				t.Errorf("wrong output %q", testOut.String())
+			}
+		case <-time.After(TM):
+			t.Error("slow or not closed by RPC")
+		}
+	})
+
+	t.Run("not allowed", func(t *testing.T) {
+		defer testOut.Reset()
+
+		n, err := launchNode(newNodeConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer n.Close()
+
+		cl, err := node.NewRPCClient(n.RPCAddress())
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if err := term(cl); err == nil {
+			t.Error("misisng error")
+		} else if err.Error() != "not allowed" {
+			t.Error("wrong errro")
+		} else if testOut.Len() != 0 {
+			t.Error("something on stdout")
+		}
+	})
+
+}
+
+func newNodeConfig() (conf node.NodeConfig) {
+	conf = node.NewNodeConfig()
+	conf.InMemoryDB = true
+	conf.Listen = "127.0.0.1:0"
+	conf.EnableListener = false
+	conf.RPCAddress = "127.0.0.1:0"
+	conf.Log.Debug = testing.Verbose()
+	conf.RemoteClose = false
+	conf.GCInterval = 0
+	return
+}
+
+func launchNode(conf node.NodeConfig) (n *node.Node, err error) {
+	reg := skyobject.NewRegistry()
+	reg.Register("User", User{})
+	reg.Register("Group", Group{})
+	if n, err = node.NewNodeReg(conf, reg); err != nil {
+		return
+	}
+	if !testing.Verbose() {
+		n.Logger.SetOutput(ioutil.Discard)
+	}
+	if err = n.Start(); err != nil {
+		n.Close()
+		return
+	}
+	return
+}

--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,3 @@ data
 ====
 
 Data represents CX objects database
-
-##### TODO
-
-- [ ] add ability to remove all non-full root objects

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -3,15 +3,17 @@ changes
 
 ### TODO
 
-- [ ] improve GC
+- [ ] improve GC (#97)
 - [ ] improve documentation
 - [ ] add RPC methods to see conn->feeds and feed->conns
-- [ ] implement Tree RPC method
-- [ ] add OnDropRoot callback
+- [ ] implement `Tree` RPC method
+- [ ] add `OnDropRoot` callback
 - [ ] add ability to remove non-full root objects that will not be filled
 - [ ] add more tests
 - [ ] dry benchmarks
 - [ ] add long running tests
+- [ ] move `RootWalker` to skyobject package
+- [ ] move `(*Node).Start()` to `NewNodeReg` ridding out of the `Start`
 
 ### Done
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -6,7 +6,6 @@ changes
 - [ ] improve GC (#97)
 - [ ] improve documentation
 - [ ] add RPC methods to see conn->feeds and feed->conns
-- [ ] implement `Tree` RPC method
 - [ ] add `OnDropRoot` callback
 - [ ] add ability to remove non-full root objects that will not be filled
 - [ ] add more tests
@@ -16,6 +15,15 @@ changes
 - [ ] move `(*Node).Start()` to `NewNodeReg` ridding out of the `Start`
 
 ### Done
+
+####  1:00 16 June 2017 UTC
+
+- [x] implement `Tree` RPC method
+
+Also
+
++ added `Roots` RPC method
++ changed arguments for `Subscribe` and `Unsubscribe` methods of `RPCClient`
 
 #### 20:40 15 June 2017 UTC
 

--- a/node/node.go
+++ b/node/node.go
@@ -1428,3 +1428,12 @@ func (s *Node) ListOfFeedsResponseTimeout(c *gnet.Conn,
 	return
 
 }
+
+// RPCAddress returns address of RPC listener or an empty
+// stirng if disabled
+func (n *Node) RPCAddress() (address string) {
+	if n.rpc != nil {
+		address = n.rpc.Address()
+	}
+	return
+}

--- a/node/rpc_client.go
+++ b/node/rpc_client.go
@@ -7,10 +7,14 @@ import (
 	"github.com/skycoin/skycoin/src/cipher"
 )
 
+// A RPCClient represents RPC client to
+// control and explore a Node
 type RPCClient struct {
 	c *rpc.Client
 }
 
+// NewRPCClient creates RPC client connected to RPC server with
+// given address
 func NewRPCClient(address string) (rc *RPCClient, err error) {
 	var c *rpc.Client
 	if c, err = rpc.Dial("tcp", address); err != nil {
@@ -21,76 +25,111 @@ func NewRPCClient(address string) (rc *RPCClient, err error) {
 	return
 }
 
+// Want returns (possible incompile) list of hashes of objects
+// that the feed knows about but doesn't have got (yet)
 func (r *RPCClient) Want(feed cipher.PubKey) (list []cipher.SHA256, err error) {
 	err = r.c.Call("cxo.Want", feed, &list)
 	return
 }
 
+// Got returns list of hashes of object the feed has got
 func (r *RPCClient) Got(feed cipher.PubKey) (list []cipher.SHA256, err error) {
 	err = r.c.Call("cxo.Got", feed, &list)
 	return
 }
 
-func (r *RPCClient) Subscribe(cf ConnFeed) (err error) {
+// Subscribe to feed. If address is empty string, then it make
+// the node susbcribed to the feed. Otherwise, it subscribes
+// to feed of a peer
+func (r *RPCClient) Subscribe(address string, feed cipher.PubKey) (err error) {
+	var cf ConnFeed
+	cf.Address = address
+	cf.Feed = feed
 	err = r.c.Call("cxo.Subscribe", cf, &struct{}{})
 	return
 }
 
-func (r *RPCClient) Unsubscribe(cf ConnFeed) (err error) {
+// Unsusbcribe from a feed. If address is emty string then it
+// unsusbcribes from feed entirely. Otherwise, from a feed of
+// a peer
+func (r *RPCClient) Unsubscribe(address string,
+	feed cipher.PubKey) (err error) {
+
+	var cf ConnFeed
+	cf.Address = address
+	cf.Feed = feed
 	err = r.c.Call("cxo.Unsubscribe", cf, &struct{}{})
 	return
 }
 
+// Feeds returns list of feeds the node subscribed to
 func (r *RPCClient) Feeds() (list []cipher.PubKey, err error) {
 	err = r.c.Call("cxo.Feeds", struct{}{}, &list)
 	return
 }
 
+// Stat returns database statistic
 func (r *RPCClient) Stat() (stat data.Stat, err error) {
 	r.c.Call("cxo.Stat", struct{}{}, &stat)
 	return
 }
 
+// Connections return list of all connections
 func (r *RPCClient) Connections() (list []string, err error) {
 	err = r.c.Call("cxo.Connections", struct{}{}, &list)
 	return
 }
 
+// IncomingConnections returns list of all incoming connections
 func (r *RPCClient) IncomingConnections() (list []string, err error) {
 	err = r.c.Call("cxo.IncomingConnections", struct{}{}, &list)
 	return
 }
 
+// OutgoingConnections returns list of all outgoing connections
 func (r *RPCClient) OutgoingConnections() (list []string, err error) {
 	err = r.c.Call("cxo.OutgoingConnections", struct{}{}, &list)
 	return
 }
 
+// Connect to a peer
 func (r *RPCClient) Connect(address string) (err error) {
 	err = r.c.Call("cxo.Connect", address, &struct{}{})
 	return
 }
 
+// Disconnect from a peer
 func (r *RPCClient) Disconnect(address string) (err error) {
 	err = r.c.Call("cxo.Disconnect", address, &struct{}{})
 	return
 }
 
+// ListeningAddress of the node
 func (r *RPCClient) ListeningAddress() (address string, err error) {
 	err = r.c.Call("cxo.ListeningAddress", struct{}{}, &address)
 	return
 }
 
-func (r *RPCClient) Tree(feed cipher.PubKey) (tree []byte, err error) {
-	err = r.c.Call("cxo.Tree", feed, &tree)
+// Roots returns breif information about all root obejts of a feed
+func (r *RPCClient) Roots(feed cipher.PubKey) (ris []RootInfo, err error) {
+	err = r.c.Call("cxo.Roots", feed, &ris)
 	return
 }
 
+// Tree returns strigified objects tree of a root object. The
+// method useful for inspecting
+func (r *RPCClient) Tree(hash cipher.SHA256) (tree string, err error) {
+	err = r.c.Call("cxo.Tree", hash, &tree)
+	return
+}
+
+// Terminate the node if allowed
 func (r *RPCClient) Terminate() (err error) {
 	err = r.c.Call("cxo.Terminate", struct{}{}, &struct{}{})
 	return
 }
 
+// Close the RPCClient
 func (r *RPCClient) Close() error {
 	return r.c.Close()
 }

--- a/node/rpc_client.go
+++ b/node/rpc_client.go
@@ -49,8 +49,8 @@ func (r *RPCClient) Subscribe(address string, feed cipher.PubKey) (err error) {
 	return
 }
 
-// Unsusbcribe from a feed. If address is emty string then it
-// unsusbcribes from feed entirely. Otherwise, from a feed of
+// Unsubscribe from a feed. If address is emty string then it
+// unsubscribes from feed entirely. Otherwise, from a feed of
 // a peer
 func (r *RPCClient) Unsubscribe(address string,
 	feed cipher.PubKey) (err error) {
@@ -110,7 +110,7 @@ func (r *RPCClient) ListeningAddress() (address string, err error) {
 	return
 }
 
-// Roots returns breif information about all root obejts of a feed
+// Roots returns brief information about all root obejts of a feed
 func (r *RPCClient) Roots(feed cipher.PubKey) (ris []RootInfo, err error) {
 	err = r.c.Call("cxo.Roots", feed, &ris)
 	return

--- a/skyobject/CHANGELOG.md
+++ b/skyobject/CHANGELOG.md
@@ -9,3 +9,12 @@ changes
 - [ ] add tests for `(*Container).RangeFeed`
 - [ ] add tests for `(*Container).RootByHash`
 - [ ] rename `(*Root).Inject, InjectMany -> Append`
+
+### Done
+
+####  1:00 16 June 2017 UTC
+
++ added `(*Root).Inspect() (tree string)` method that retuerns printed tree of
+the Root
++ added `(*Container).RootByHash() (r *Root, ok bool)`
++ added `(*Container).RangeFeed(RangeFeedFun) (err error)`

--- a/skyobject/CHANGELOG.md
+++ b/skyobject/CHANGELOG.md
@@ -1,0 +1,11 @@
+changes
+=======
+
+### TODO
+
+- [ ] add ability to remove all non-full root objects
+- [ ] move `node.Rootwalker` here
+- [ ] fix user-provided-schema-name issue #98
+- [ ] add tests for `(*Container).RangeFeed`
+- [ ] add tests for `(*Container).RootByHash`
+- [ ] rename `(*Root).Inject, InjectMany -> Append`

--- a/skyobject/inspect.go
+++ b/skyobject/inspect.go
@@ -1,0 +1,163 @@
+package skyobject
+
+import (
+	"encoding/hex"
+	"fmt"
+	"reflect"
+
+	"github.com/disiqueira/gotree" // alpha
+)
+
+// Inspect returns string that contains printed
+// object tree of this root object. The tree doesn't
+// containe information about seq, timestamp and feed
+// of the root
+func (r *Root) Inspect() (tree string) {
+	var rt gotree.GTStructure
+
+	hash := r.Hash()
+	rt.Name = "(root) " + hash.String()
+	rt.Items = rootItems(r)
+	tree = gotree.StringTree(rt)
+
+	return
+}
+
+func rootItems(root *Root) (items []gotree.GTStructure) {
+	vals, err := root.Values()
+	if err != nil {
+		items = []gotree.GTStructure{
+			gotree.GTStructure{Name: "error: " + err.Error()},
+		}
+		return
+	}
+	for _, val := range vals {
+		items = append(items, valueItem(val))
+	}
+	return
+}
+
+func valueItem(val *Value) (item gotree.GTStructure) {
+	if val.IsNil() {
+		item.Name = "nil"
+		return
+	}
+
+	var err error
+	switch val.Kind() {
+	case reflect.Struct:
+		item.Name = "struct " + val.Schema().Name()
+
+		err = val.RangeFields(func(name string,
+			val *Value) (_ error) {
+
+			var field gotree.GTStructure
+			field.Name = "(field) " + name
+			field.Items = []gotree.GTStructure{
+				valueItem(val),
+			}
+			item.Items = append(item.Items, field)
+			return
+		})
+	case reflect.Ptr:
+
+		if val.Schema().ReferenceType() == ReferenceTypeSingle {
+			var ref Reference
+			if ref, err = val.Static(); err != nil {
+				break
+			}
+			item.Name = "*(static) " + ref.String()
+		} else { // dynamic reference
+			var dr Dynamic
+			if dr, err = val.Dynamic(); err != nil {
+				break
+			}
+			item.Name = "*(dynamic) " + dr.String()
+		}
+
+		if val, err = val.Dereference(); err == nil {
+			item.Items = []gotree.GTStructure{
+				valueItem(val),
+			}
+		} else {
+			item.Items = []gotree.GTStructure{
+				gotree.GTStructure{
+					Name: "error: " + err.Error(),
+				},
+			}
+
+		}
+		return
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		var i int64
+		if i, err = val.Int(); err == nil {
+			item.Name = fmt.Sprint(i)
+		}
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		var u uint64
+		if u, err = val.Uint(); err == nil {
+			item.Name = fmt.Sprint(u)
+		}
+	case reflect.Float32, reflect.Float64:
+		var f float64
+		if f, err = val.Float(); err == nil {
+			item.Name = fmt.Sprint(f)
+		}
+	case reflect.Array:
+		item.Name = val.Schema().Name()
+		if item.Name == "" {
+			// unnamed type
+			var ln int
+			if ln, err = val.Len(); err != nil {
+				break
+			}
+			if val.Schema().Elem() == nil {
+				err = ErrInvalidSchema
+				break
+			}
+			item.Name = fmt.Sprintf("[%d]", ln) + val.Schema().Elem().String()
+		}
+		err = val.RangeIndex(func(_ int, val *Value) (_ error) {
+			item.Items = append(item.Items, valueItem(val))
+			return
+		})
+	case reflect.Slice:
+		// special case for []byte
+		sch := val.Schema()
+		if sch.Kind() == reflect.Slice && sch.Elem().Kind() == reflect.Uint8 {
+			var bt []byte
+			if bt, err = val.Bytes(); err != nil {
+				break
+			}
+			item.Name = "[]byte"
+			item.Items = []gotree.GTStructure{
+				gotree.GTStructure{Name: hex.EncodeToString(bt)},
+			}
+			return
+		}
+		// including References
+		if item.Name = sch.Name(); item.Name == "" {
+			// unnamed type
+			if sch.Elem() == nil {
+				err = ErrInvalidSchema
+				break
+			}
+			item.Name = "[]" + sch.Elem().String()
+		}
+		err = val.RangeIndex(func(_ int, val *Value) (_ error) {
+			item.Items = append(item.Items, valueItem(val))
+			return
+		})
+	case reflect.String:
+		var s string
+		if s, err = val.String(); err == nil {
+			item.Name = s
+		}
+
+	}
+	if err != nil {
+		item.Name = "error: " + err.Error()
+		item.Items = nil // clear
+	}
+	return
+}


### PR DESCRIPTION
##### cmd/cxocli

- [x] change subscribe_to from optimistic to based on `SubscribeResponse`
- [x] implement `tree` command
- [x] suppress stdout output for tests

##### node

- [x] implement `Tree` RPC method

Also

+ added `Roots` RPC method
+ changed arguments for `Subscribe` and `Unsubscribe` methods of `RPCClient`

##### skyobject

+ added `(*Root).Inspect() (tree string)` method that retuerns printed tree of the Root
+ added `(*Container).RootByHash() (r *Root, ok bool)`
+ added `(*Container).RangeFeed(RangeFeedFun) (err error)`