### PR TITLE
skyiobjet and node changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go:
+  - tip
+before_install:
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+  - go get -t ./...
+script:
+  - go test ./...
+  - bash coverage.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 CX Object System
 ================
 
+[![Build Status](https://travis-ci.org/skycoin/cxo.svg)](https://travis-ci.org/skycoin/cxo)
+[![Coverage Status](https://coveralls.io/repos/skycoin/cxo/badge.svg?branch=master)](https://coveralls.io/r/skycoin/cxo?branch=master)
+[![GoReportCard](https://goreportcard.com/badge/skycoin/cxo)](https://goreportcard.com/report/skycoin/cxo)
+
 Specs: https://pad.riseup.net/p/cxo
 
 ## Packages

--- a/cmd/cxocli/CHANGELOG.md
+++ b/cmd/cxocli/CHANGELOG.md
@@ -9,7 +9,7 @@ changes
 
 ### Done
 
-####  1:00 16 June 2017 UTC
+#### 16:15 17 June 2017 UTC
 
 - [x] change subscribe_to from optimistic to based on `SubscribeResponse`
 - [x] implement `tree` command

--- a/cmd/cxocli/cxocli.go
+++ b/cmd/cxocli/cxocli.go
@@ -18,17 +18,18 @@ import (
 	"github.com/skycoin/cxo/node"
 )
 
+// defaults
 const (
-	HISTORY = ".cxocli.history"
-	ADDRESS = "[::]:8997"
+	HISTORY = ".cxocli.history" // history file name
+	ADDRESS = "[::]:8997"       // default RPC address to connect to
 )
 
 var (
 	out io.Writer = os.Stdout // it's nessesary for tests
 
-	ErrUnknowCommand    = errors.New("unknown command")
-	ErrMisisngArgument  = errors.New("missing argument")
-	ErrTooManyArguments = errors.New("too many arguments")
+	errUnknowCommand    = errors.New("unknown command")
+	errMisisngArgument  = errors.New("missing argument")
+	errTooManyArguments = errors.New("too many arguments")
 
 	commands = []string{
 		"want",
@@ -207,11 +208,11 @@ Error:
 func args(ss []string) (string, error) {
 	switch len(ss) {
 	case 0, 1:
-		return "", ErrMisisngArgument
+		return "", errMisisngArgument
 	case 2:
 		return ss[1], nil
 	}
-	return "", ErrTooManyArguments
+	return "", errTooManyArguments
 }
 
 func executeCommand(command string, rpc *node.RPCClient) (terminate bool,
@@ -229,11 +230,11 @@ func executeCommand(command string, rpc *node.RPCClient) (terminate bool,
 	case "subscribe":
 		err = subscribe(rpc, ss)
 	case "subscribe_to":
-		err = subscribe_to(rpc, ss)
+		err = subscribeTo(rpc, ss)
 	case "unsubscribe":
 		err = unsubscribe(rpc, ss)
 	case "unsubscribe_from":
-		err = unsubscribe_from(rpc, ss)
+		err = unsubscribeFrom(rpc, ss)
 	case "feeds":
 		err = feeds(rpc)
 	case "stat":
@@ -241,15 +242,15 @@ func executeCommand(command string, rpc *node.RPCClient) (terminate bool,
 	case "connections":
 		err = connections(rpc)
 	case "incoming_connections":
-		err = incoming_connections(rpc)
+		err = incomingConnections(rpc)
 	case "outgoing_connections":
-		err = outgoing_connections(rpc)
+		err = outgoingConnections(rpc)
 	case "connect":
 		err = connect(rpc, ss)
 	case "disconnect":
 		err = disconnect(rpc, ss)
 	case "listening_address":
-		err = listening_address(rpc)
+		err = listeningAddress(rpc)
 	case "roots":
 		err = roots(rpc, ss)
 	case "tree":
@@ -263,7 +264,7 @@ func executeCommand(command string, rpc *node.RPCClient) (terminate bool,
 		terminate = true
 		fmt.Fprintln(out, "cya")
 	default:
-		err = ErrUnknowCommand
+		err = errUnknowCommand
 	}
 	return
 }
@@ -382,17 +383,17 @@ func addressFeedArgs(ss []string) (address string, pk cipher.PubKey,
 
 	switch len(ss) {
 	case 0, 1, 2:
-		err = ErrMisisngArgument
+		err = errMisisngArgument
 	case 3:
 		address = ss[1]
 		pk, err = cipher.PubKeyFromHex(ss[2])
 	default:
-		err = ErrTooManyArguments
+		err = errTooManyArguments
 	}
 	return
 }
 
-func subscribe_to(rpc *node.RPCClient, ss []string) (err error) {
+func subscribeTo(rpc *node.RPCClient, ss []string) (err error) {
 	var pk cipher.PubKey
 	var address string
 	if address, pk, err = addressFeedArgs(ss); err != nil {
@@ -417,7 +418,7 @@ func unsubscribe(rpc *node.RPCClient, ss []string) (err error) {
 	return
 }
 
-func unsubscribe_from(rpc *node.RPCClient, ss []string) (err error) {
+func unsubscribeFrom(rpc *node.RPCClient, ss []string) (err error) {
 	var pk cipher.PubKey
 	var address string
 	if address, pk, err = addressFeedArgs(ss); err != nil {
@@ -480,7 +481,7 @@ func connections(rpc *node.RPCClient) (err error) {
 	return
 }
 
-func incoming_connections(rpc *node.RPCClient) (err error) {
+func incomingConnections(rpc *node.RPCClient) (err error) {
 	var list []string
 	if list, err = rpc.IncomingConnections(); err != nil {
 		return
@@ -495,7 +496,7 @@ func incoming_connections(rpc *node.RPCClient) (err error) {
 	return
 }
 
-func outgoing_connections(rpc *node.RPCClient) (err error) {
+func outgoingConnections(rpc *node.RPCClient) (err error) {
 	var list []string
 	if list, err = rpc.OutgoingConnections(); err != nil {
 		return
@@ -534,7 +535,7 @@ func disconnect(rpc *node.RPCClient, ss []string) (err error) {
 	return
 }
 
-func listening_address(rpc *node.RPCClient) (err error) {
+func listeningAddress(rpc *node.RPCClient) (err error) {
 	var address string
 	if address, err = rpc.ListeningAddress(); err != nil {
 		return

--- a/cmd/cxocli/cxocli_test.go
+++ b/cmd/cxocli/cxocli_test.go
@@ -308,6 +308,8 @@ func Test_tree(t *testing.T) {
 
 	if out != fmt.Sprintf(want, hash.String()) {
 		t.Error("wrong output")
+		t.Log(out)
+		t.Log(fmt.Sprintf(want, hash.String()))
 	}
 }
 

--- a/cmd/cxocli/cxocli_test.go
+++ b/cmd/cxocli/cxocli_test.go
@@ -29,7 +29,7 @@ type Group struct {
 	Users skyobject.References `skyobject:"schema=User"`
 }
 
-var testOut *bytes.Buffer = new(bytes.Buffer)
+var testOut = new(bytes.Buffer)
 
 func init() {
 	out = testOut // owerwrite
@@ -375,8 +375,8 @@ func Test_term(t *testing.T) {
 
 }
 
-func newNodeConfig() (conf node.NodeConfig) {
-	conf = node.NewNodeConfig()
+func newNodeConfig() (conf node.Config) {
+	conf = node.NewConfig()
 	conf.InMemoryDB = true
 	conf.Listen = "127.0.0.1:0"
 	conf.EnableListener = false
@@ -387,7 +387,7 @@ func newNodeConfig() (conf node.NodeConfig) {
 	return
 }
 
-func launchNode(conf node.NodeConfig) (n *node.Node, err error) {
+func launchNode(conf node.Config) (n *node.Node, err error) {
 	reg := skyobject.NewRegistry()
 	reg.Register("User", User{})
 	reg.Register("Group", Group{})

--- a/cmd/cxocli/cxocli_test.go
+++ b/cmd/cxocli/cxocli_test.go
@@ -257,7 +257,7 @@ func Test_tree(t *testing.T) {
 		return
 	}
 
-	root.Inject("Group", Group{
+	root.Append(root.MustDynamic("Group", Group{
 		Name: "Just an average Group",
 		Users: root.SaveArray(
 			User{
@@ -269,7 +269,7 @@ func Test_tree(t *testing.T) {
 				Age:  80,
 			},
 		),
-	})
+	}))
 
 	hash := root.Hash()
 

--- a/cmd/cxod/cxod.go
+++ b/cmd/cxod/cxod.go
@@ -13,7 +13,7 @@ import (
 const (
 	Host        string = "[::]:8998" // default host address of the server
 	RPC         string = "[::]:8997" // default RPC address
-	RemoteClose bool   = false
+	RemoteClose bool   = false       // don't allow closing by RPC by default
 )
 
 func waitInterrupt(quit <-chan struct{}) {
@@ -31,7 +31,7 @@ func main() {
 
 	defer func() { os.Exit(code) }()
 
-	var c node.NodeConfig = node.NewNodeConfig()
+	var c = node.NewConfig()
 
 	c.RPCAddress = RPC
 	c.Listen = Host

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "mode: set" > cover.out
+for Dir in $(find ./* -maxdepth 10 -type d ); 
+do
+	if ls $Dir/*.go &> /dev/null;
+	then
+		returnval=`go test -coverprofile=temp.out $Dir`
+		echo ${returnval}
+		if [[ ${returnval} != *FAIL* ]]
+		then
+    		if [ -f temp.out ]
+    		then
+        		cat temp.out | grep -v "mode: set" >> cover.out 
+    		fi
+    	else
+    		exit 1
+    	fi	
+    fi
+done
+
+goveralls -service=travis-ci -coverprofile=cover.out
+
+rm -rf ./temp.out
+rm -rf ./cover.out

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -199,7 +199,7 @@ func TestData_IsExist(t *testing.T) {
 }
 
 func testDataRange(t *testing.T, db DB) {
-	var vals [][]byte = [][]byte{
+	var vals = [][]byte{
 		[]byte("one"),
 		[]byte("two"),
 		[]byte("othree"),
@@ -208,7 +208,7 @@ func testDataRange(t *testing.T, db DB) {
 	for _, val := range vals {
 		db.Add(val)
 	}
-	var collect map[cipher.SHA256][]byte = make(map[cipher.SHA256][]byte)
+	var collect = make(map[cipher.SHA256][]byte)
 	db.Range(func(key cipher.SHA256, value []byte) (stop bool) {
 		collect[key] = value
 		return
@@ -553,7 +553,7 @@ func getRootPack(seq uint64, content string) (rp RootPack) {
 func testRangeFeed(t *testing.T, db DB) {
 	pk, _ := cipher.GenerateKeyPair()
 	// no feed
-	var i int = 0
+	var i int
 	db.RangeFeed(pk, func(*RootPack) (stop bool) {
 		i++
 		return
@@ -627,7 +627,7 @@ func TestData_RangeFeed(t *testing.T) {
 func testRangeFeedReverese(t *testing.T, db DB) {
 	pk, _ := cipher.GenerateKeyPair()
 	// no feed
-	var i int = 0
+	var i int
 	db.RangeFeedReverse(pk, func(*RootPack) (stop bool) {
 		i++
 		return

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -288,8 +288,8 @@ func testDataFeeds(t *testing.T, db DB) {
 		t.Error("wrong feeds length")
 	} else {
 		pks := map[cipher.PubKey]struct{}{
-			pk1: struct{}{},
-			pk2: struct{}{},
+			pk1: {},
+			pk2: {},
 		}
 		for _, pk := range fs {
 			if _, ok := pks[pk]; !ok {

--- a/data/drive.go
+++ b/data/drive.go
@@ -15,9 +15,9 @@ const dbMode = 0644
 
 // names of buckets
 var (
-	objectsBucket []byte = []byte("objects")
-	rootsBucket   []byte = []byte("roots")
-	feedsBucket   []byte = []byte("feeds")
+	objectsBucket = []byte("objects")
+	rootsBucket   = []byte("roots")
+	feedsBucket   = []byte("feeds")
 )
 
 // buckets:
@@ -407,11 +407,13 @@ func (d *driveDB) Stat() (s Stat) {
 		// feeds
 		f := t.Bucket(feedsBucket)
 		r := t.Bucket(rootsBucket)
-		if feeds := f.Stats().KeyN; feeds == 0 {
+		//
+		feeds := f.Stats().KeyN
+		if feeds == 0 {
 			return // no feeds
-		} else {
-			s.Feeds = make(map[cipher.PubKey]FeedStat, feeds)
 		}
+		s.Feeds = make(map[cipher.PubKey]FeedStat, feeds)
+		//
 		var pk cipher.PubKey
 		// for each feed
 		e = f.ForEach(func(pkb, _ []byte) (_ error) {

--- a/data/memory.go
+++ b/data/memory.go
@@ -109,15 +109,15 @@ func (d *memoryDB) HasFeed(pk cipher.PubKey) (has bool) {
 	return
 }
 
-func (m *memoryDB) Feeds() (fs []cipher.PubKey) {
-	m.mx.RLock()
-	defer m.mx.RUnlock()
+func (d *memoryDB) Feeds() (fs []cipher.PubKey) {
+	d.mx.RLock()
+	defer d.mx.RUnlock()
 
-	if len(m.feeds) == 0 {
+	if len(d.feeds) == 0 {
 		return
 	}
-	fs = make([]cipher.PubKey, 0, len(m.feeds))
-	for pk := range m.feeds {
+	fs = make([]cipher.PubKey, 0, len(d.feeds))
+	for pk := range d.feeds {
 		fs = append(fs, pk)
 	}
 	return
@@ -134,7 +134,7 @@ func (d *memoryDB) DelFeed(pk cipher.PubKey) {
 }
 
 func (d *memoryDB) AddRoot(pk cipher.PubKey, rr *RootPack) (err error) {
-	var rp *RootPack = new(RootPack)
+	rp := new(RootPack)
 	*rp = *rr // copy (required)
 	// test given rp
 	if rp.Seq == 0 {
@@ -182,7 +182,7 @@ func (d *memoryDB) LastRoot(pk cipher.PubKey) (rp *RootPack, ok bool) {
 	if len(roots) == 0 {
 		return // bo roots
 	}
-	var max uint64 = 0
+	var max uint64
 	for seq := range roots {
 		if max < seq {
 			max = seq
@@ -205,7 +205,7 @@ func (d *memoryDB) RangeFeed(pk cipher.PubKey,
 		return // empty feed
 	}
 
-	var o order = make(order, 0, len(roots))
+	var o = make(order, 0, len(roots))
 	for seq := range roots {
 		o = append(o, seq)
 	}
@@ -235,7 +235,7 @@ func (d *memoryDB) RangeFeedReverse(pk cipher.PubKey,
 		return // empty feed
 	}
 
-	var o order = make(order, 0, len(roots))
+	var o = make(order, 0, len(roots))
 	for seq := range roots {
 		o = append(o, seq)
 	}
@@ -275,7 +275,7 @@ func (d *memoryDB) DelRootsBefore(pk cipher.PubKey, seq uint64) {
 		return // empty feed
 	}
 
-	var o order = make(order, 0, len(roots))
+	var o = make(order, 0, len(roots))
 	for s := range roots {
 		if s < seq {
 			o = append(o, s)
@@ -306,7 +306,7 @@ func (d *memoryDB) Stat() (s Stat) {
 	}
 	s.Feeds = make(map[cipher.PubKey]FeedStat, len(d.feeds))
 	// lengths of Prev, Hash, Sig and Seq (8 byte)
-	var add int = len(cipher.SHA256{})*2 + len(cipher.Sig{}) + 8
+	add := len(cipher.SHA256{})*2 + len(cipher.Sig{}) + 8
 	for pk, rs := range d.feeds {
 		var fs FeedStat
 		for _, hash := range rs {

--- a/data/stat.go
+++ b/data/stat.go
@@ -65,8 +65,8 @@ func (s Stat) String() (x string) {
 
 // HumanMemory returns human readable memory string
 func HumanMemory(bytes int) string {
-	var fb float64 = float64(bytes)
-	var ms string = "B"
+	fb := float64(bytes)
+	ms := "B"
 	for _, m := range []string{"KiB", "MiB", "GiB"} {
 		if fb > 1024.0 {
 			fb = fb / 1024.0

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -26,6 +26,11 @@ Also
 - there are changes in skyobject package
 - GC disabled by default
 
+
+And there is breaking changes:
+
+- `NodeConfig` renamed to `Config` following golang linter recommendations
+
 ####  1:00 16 June 2017 UTC
 
 - [x] implement `Tree` RPC method

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -12,13 +12,18 @@ changes
 - [ ] dry benchmarks
 - [ ] add long running tests
 - [ ] move `RootWalker` to skyobject package
-- [ ] move `(*Node).Start()` to `NewNodeReg` ridding out of the `Start`
 
 ### Done
 
-#### 13:20 16 June 2017 UTC
+#### 14:00 17 June 2017 UTC
 
-- there are breaking changes in skyobject package
+- [x] move `(*Node).Start()` to `NewNodeReg`
+
+The `(*Node).Start` is deprecated and has been replaced by a stub.
+
+Also
+
+- there are changes in skyobject package
 - GC disabled by default
 
 ####  1:00 16 June 2017 UTC

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -16,6 +16,10 @@ changes
 
 ### Done
 
+#### 13:20 16 June 2017 UTC
+
+There are breaking changes in skyobject package.
+
 ####  1:00 16 June 2017 UTC
 
 - [x] implement `Tree` RPC method

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -15,7 +15,7 @@ changes
 
 ### Done
 
-#### 14:00 17 June 2017 UTC
+#### 16:15 17 June 2017 UTC
 
 - [x] move `(*Node).Start()` to `NewNodeReg`
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -18,7 +18,8 @@ changes
 
 #### 13:20 16 June 2017 UTC
 
-There are breaking changes in skyobject package.
+- there are breaking changes in skyobject package
+- GC disabled by default
 
 ####  1:00 16 June 2017 UTC
 

--- a/node/config.go
+++ b/node/config.go
@@ -37,7 +37,7 @@ const (
 
 	// GCInterval is default valie for GC
 	// triggering interval
-	GCInterval time.Duration = 5 * time.Second
+	GCInterval time.Duration = 0 * 5 * time.Second
 
 	PublicServer bool = false // default
 

--- a/node/config.go
+++ b/node/config.go
@@ -65,12 +65,12 @@ func initDataDir(dir string) error {
 	return os.MkdirAll(dir, 0700)
 }
 
-// A NodeConfig represnets configurations
+// A Config represnets configurations
 // of a Node. The config contains configurations
 // for gnet.Pool and  for log.Logger. If logger of
-// gnet.Config is nil, then logger of NodeConfig
+// gnet.Config is nil, then logger of Config
 // will be used
-type NodeConfig struct {
+type Config struct {
 	gnet.Config // pool confirations
 
 	Log log.Config // logger configurations
@@ -154,9 +154,9 @@ type NodeConfig struct {
 	OnRootFilled func(root *Root)
 }
 
-// NewNodeConfig returns NodeConfig
+// NewConfig returns Config
 // filled with default values
-func NewNodeConfig() (sc NodeConfig) {
+func NewConfig() (sc Config) {
 	sc.Config = gnet.NewConfig()
 	sc.Log = log.NewConfig()
 	sc.EnableRPC = EnableRPC
@@ -178,11 +178,11 @@ func NewNodeConfig() (sc NodeConfig) {
 // FromFlags obtains value from command line flags.
 // Call the method before `flag.Parse` for example
 //
-//     c := node.NewNodeConfig()
+//     c := node.NewConfig()
 //     c.FromFlags()
 //     flag.Parse()
 //
-func (s *NodeConfig) FromFlags() {
+func (s *Config) FromFlags() {
 	s.Config.FromFlags()
 	s.Log.FromFlags()
 

--- a/node/container.go
+++ b/node/container.go
@@ -157,7 +157,7 @@ func (r *Root) Append(drs ...skyobject.Dynamic) (rp data.RootPack, err error) {
 	return
 }
 
-// Repalce wrapper
+// Replace wrapper
 func (r *Root) Replace(refs []skyobject.Dynamic) (rp data.RootPack, err error) {
 	if rp, err = r.Root.Replace(refs); err == nil {
 		r.send(rp)

--- a/node/container.go
+++ b/node/container.go
@@ -124,6 +124,31 @@ func (r *Root) Touch() (rp data.RootPack, err error) {
 	return
 }
 
+// Inject wrapper
+//
+// Deprecated: use Append instead
+func (r *Root) Inject(schemName string, i interface{}) (inj skyobject.Dynamic,
+	rp data.RootPack, err error) {
+
+	if inj, rp, err = r.Root.Inject(schemName, i); err == nil {
+		r.send(rp)
+	}
+	return
+}
+
+// InjectMany wrapper
+//
+// Deprecated: use Append instead
+func (r *Root) InjectMany(schemaName string,
+	i ...interface{}) (injs []skyobject.Dynamic, rp data.RootPack,
+	err error) {
+
+	if injs, rp, err = r.Root.InjectMany(schemaName, i...); err == nil {
+		r.send(rp)
+	}
+	return
+}
+
 // Append wrapper
 func (r *Root) Append(drs ...skyobject.Dynamic) (rp data.RootPack, err error) {
 	if rp, err = r.Root.Append(drs...); err == nil {

--- a/node/container.go
+++ b/node/container.go
@@ -89,6 +89,15 @@ func (c *Container) LastFullRoot(pk cipher.PubKey) (r *Root) {
 	return
 }
 
+// RootByHash wrapper
+func (c *Container) RootByHash(rr skyobject.RootReference) (r *Root, ok bool) {
+	var sr *skyobject.Root
+	if sr, ok = c.Container.RootByHash(rr); sr != nil {
+		r = c.wrapRoot(sr)
+	}
+	return
+}
+
 // A Root represents wrapper of *skyobject.Root that
 // shares all changes
 type Root struct {
@@ -115,32 +124,17 @@ func (r *Root) Touch() (rp data.RootPack, err error) {
 	return
 }
 
-// Inject wrapper
-func (r *Root) Inject(schemName string, i interface{}) (inj skyobject.Dynamic,
-	rp data.RootPack, err error) {
-
-	if inj, rp, err = r.Root.Inject(schemName, i); err == nil {
-		r.send(rp)
-	}
-	return
-}
-
-// InjectMany wrapper
-func (r *Root) InjectMany(schemaName string,
-	i ...interface{}) (injs []skyobject.Dynamic, rp data.RootPack,
-	err error) {
-
-	if injs, rp, err = r.Root.InjectMany(schemaName, i...); err == nil {
+// Append wrapper
+func (r *Root) Append(drs ...skyobject.Dynamic) (rp data.RootPack, err error) {
+	if rp, err = r.Root.Append(drs...); err == nil {
 		r.send(rp)
 	}
 	return
 }
 
 // Repalce wrapper
-func (r *Root) Replace(refs []skyobject.Dynamic) (prev []skyobject.Dynamic,
-	rp data.RootPack, err error) {
-
-	if prev, rp, err = r.Root.Replace(refs); err == nil {
+func (r *Root) Replace(refs []skyobject.Dynamic) (rp data.RootPack, err error) {
+	if rp, err = r.Root.Replace(refs); err == nil {
 		r.send(rp)
 	}
 	return

--- a/node/example_test.go
+++ b/node/example_test.go
@@ -216,7 +216,7 @@ func rootItems(root *node.Root) (items []gotree.GTStructure) {
 	vals, err := root.Values()
 	if err != nil {
 		items = []gotree.GTStructure{
-			gotree.GTStructure{Name: "error: " + err.Error()},
+			{Name: "error: " + err.Error()},
 		}
 		return
 	}
@@ -257,7 +257,7 @@ func valueItem(val *skyobject.Value) (item gotree.GTStructure) {
 			}
 		} else {
 			item.Items = []gotree.GTStructure{
-				gotree.GTStructure{
+				{
 					Name: "error: " + err.Error(),
 				},
 			}

--- a/node/example_test.go
+++ b/node/example_test.go
@@ -128,7 +128,7 @@ func generateGroup(i int, cnt *node.Container, root *node.Root) {
 	cnt.LockGC()
 	defer cnt.UnlockGC()
 
-	_, _, err := root.Inject("cxo.Group", Group{
+	group, err := root.Dynamic("cxo.Group", Group{
 		Name: fmt.Sprint("Group #", i),
 		Leader: root.Save(User{
 			Name: "Elisabet Bathory",
@@ -139,8 +139,12 @@ func generateGroup(i int, cnt *node.Container, root *node.Root) {
 			User{fmt.Sprintf("Eva #%d", i), 21 + uint32(i)},
 		),
 	})
-
 	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	if _, err := root.Append(group); err != nil {
 		log.Print(err)
 	}
 

--- a/node/example_test.go
+++ b/node/example_test.go
@@ -82,11 +82,6 @@ func SourceNode(feed cipher.PubKey, owner cipher.SecKey) (src *node.Node,
 		return
 	}
 
-	if err = src.Start(); err != nil {
-		src.Close()
-		return
-	}
-
 	// feed
 
 	src.Subscribe(nil, feed)
@@ -171,11 +166,6 @@ func DestinationNode(feed cipher.PubKey, address string) (dst *node.Node,
 
 	dst, err = node.NewNode(conf)
 	if err != nil {
-		return
-	}
-
-	if err = dst.Start(); err != nil {
-		dst.Close()
 		return
 	}
 

--- a/node/example_test.go
+++ b/node/example_test.go
@@ -69,7 +69,7 @@ func SourceNode(feed cipher.PubKey, owner cipher.SecKey) (src *node.Node,
 
 	// config
 
-	conf := node.NewNodeConfig()
+	conf := node.NewConfig()
 	conf.Listen = "127.0.0.1:0" // arbitrary assignment
 	conf.InMemoryDB = true      // use in-memory database
 	conf.EnableRPC = false      // disable RPC
@@ -150,7 +150,7 @@ func DestinationNode(feed cipher.PubKey, address string) (dst *node.Node,
 
 	// config
 
-	conf := node.NewNodeConfig()
+	conf := node.NewConfig()
 	conf.EnableListener = false // disable listener for this example
 	conf.InMemoryDB = true      // use database in memory
 	conf.EnableRPC = false

--- a/node/gnet/config_test.go
+++ b/node/gnet/config_test.go
@@ -8,51 +8,51 @@ import (
 func TestNewConfig(t *testing.T) {
 	c := NewConfig()
 	if c.MaxConnections != MaxConnections {
-		t.Error("unexpected MaxConnections, want %v, got %v",
+		t.Errorf("unexpected MaxConnections, want %v, got %v",
 			MaxConnections, c.MaxConnections)
 	}
 	if c.MaxMessageSize != MaxMessageSize {
-		t.Error("unexpected MaxMessageSize, want %v, got %v",
+		t.Errorf("unexpected MaxMessageSize, want %v, got %v",
 			MaxMessageSize, c.MaxMessageSize)
 	}
 	if c.DialTimeout != DialTimeout {
-		t.Error("unexpected DialTimeout, want %v, got %v",
+		t.Errorf("unexpected DialTimeout, want %v, got %v",
 			DialTimeout, c.DialTimeout)
 	}
 	if c.ReadTimeout != ReadTimeout {
-		t.Error("unexpected ReadTimeout, want %v, got %v",
+		t.Errorf("unexpected ReadTimeout, want %v, got %v",
 			ReadTimeout, c.ReadTimeout)
 	}
 	if c.WriteTimeout != WriteTimeout {
-		t.Error("unexpected WriteTimeout, want %v, got %v",
+		t.Errorf("unexpected WriteTimeout, want %v, got %v",
 			WriteTimeout, c.WriteTimeout)
 	}
 	if c.ReadQueueLen != ReadQueueLen {
-		t.Error("unexpected ReadQueueLen, want %v, got %v",
+		t.Errorf("unexpected ReadQueueLen, want %v, got %v",
 			ReadQueueLen, c.ReadQueueLen)
 	}
 	if c.WriteQueueLen != WriteQueueLen {
-		t.Error("unexpected WriteQueueLen, want %v, got %v",
+		t.Errorf("unexpected WriteQueueLen, want %v, got %v",
 			WriteQueueLen, c.WriteQueueLen)
 	}
 	if c.RedialTimeout != RedialTimeout {
-		t.Error("unexpected RedialTimeout, want %v, got %v",
+		t.Errorf("unexpected RedialTimeout, want %v, got %v",
 			RedialTimeout, c.RedialTimeout)
 	}
 	if c.MaxRedialTimeout != MaxRedialTimeout {
-		t.Error("unexpected MaxRedialTimeout, want %v, got %v",
+		t.Errorf("unexpected MaxRedialTimeout, want %v, got %v",
 			MaxRedialTimeout, c.MaxRedialTimeout)
 	}
 	if c.DialsLimit != DialsLimit {
-		t.Error("unexpected DialsLimit, want %v, got %v",
+		t.Errorf("unexpected DialsLimit, want %v, got %v",
 			DialsLimit, c.DialsLimit)
 	}
 	if c.ReadBufferSize != ReadBufferSize {
-		t.Error("unexpected ReadBufferSize, want %v, got %v",
+		t.Errorf("unexpected ReadBufferSize, want %v, got %v",
 			ReadBufferSize, c.ReadBufferSize)
 	}
 	if c.WriteBufferSize != WriteBufferSize {
-		t.Error("unexpected WriteBufferSize, want %v, got %v",
+		t.Errorf("unexpected WriteBufferSize, want %v, got %v",
 			WriteBufferSize, c.WriteBufferSize)
 	}
 }

--- a/node/gnet/conn.go
+++ b/node/gnet/conn.go
@@ -35,6 +35,19 @@ func (c ConnState) String() string {
 	return fmt.Sprintf("ConnState<%d>", c)
 }
 
+// A Conn represents conenction. The Conn can has and can has
+// not underlying TCP conenction. The Conn recereates connection
+// if it fails. This behaviour should be configures. There are
+// DialTimeout, RedialTimeout, MaxRedialTimeout and DialsLimit
+// configuration.Also, you can control dialing and redialing
+// using Config.OnDial callback that called when a Conn tries
+// to dial or redial. To detect current state of connection
+// use State method. The state can be ConnStateConnected,
+// ConnStateDialing and ConnStateClosed. But the state can
+// be changed any time after. If the state is ConnStateClosed
+// then it will not be changed anymore. Use Clsoe method to
+// terminate conenction and wait until it release associated
+// resources (goroutines, TCP connection, buffers)
 type Conn struct {
 	address string // diaing address
 
@@ -179,26 +192,26 @@ func (c *Conn) closeConnection() {
 	}
 }
 
-func (cn *Conn) dialing() (c net.Conn, err error) {
-	cn.p.Debug("dialing to ", cn.address)
+func (c *Conn) dialing() (conn net.Conn, err error) {
+	c.p.Debug("dialing to ", c.address)
 
 	// tcp or tls
-	if cn.p.conf.TLSConfig == nil {
+	if c.p.conf.TLSConfig == nil {
 		// timeout or not
-		if cn.p.conf.DialTimeout > 0 {
-			c, err = net.DialTimeout("tcp", cn.address, cn.p.conf.DialTimeout)
+		if c.p.conf.DialTimeout > 0 {
+			conn, err = net.DialTimeout("tcp", c.address, c.p.conf.DialTimeout)
 		} else {
-			c, err = net.Dial("tcp", cn.address)
+			conn, err = net.Dial("tcp", c.address)
 		}
 	} else {
 		// timeout or not
-		if cn.p.conf.DialTimeout > 0 {
+		if c.p.conf.DialTimeout > 0 {
 			var d net.Dialer
-			d.Timeout = cn.p.conf.DialTimeout
-			c, err = tls.DialWithDialer(&d, "tcp", cn.address,
-				cn.p.conf.TLSConfig)
+			d.Timeout = c.p.conf.DialTimeout
+			conn, err = tls.DialWithDialer(&d, "tcp", c.address,
+				c.p.conf.TLSConfig)
 		} else {
-			c, err = tls.Dial("tcp", cn.address, cn.p.conf.TLSConfig)
+			conn, err = tls.Dial("tcp", c.address, c.p.conf.TLSConfig)
 		}
 	}
 	return
@@ -289,14 +302,14 @@ func (c *Conn) connectionWriter(conn net.Conn) (w io.Writer, bw *bufio.Writer) {
 	return
 }
 
-func (cn *Conn) updateConnection(c net.Conn) {
-	cn.p.Debug("update connection of ", cn.address)
+func (c *Conn) updateConnection(conn net.Conn) {
+	c.p.Debug("update connection of ", c.address)
 
-	cn.cmx.Lock()
-	defer cn.cmx.Unlock()
+	c.cmx.Lock()
+	defer c.cmx.Unlock()
 
-	cn.conn = c
-	cn.state = ConnStateConnected
+	c.conn = conn
+	c.state = ConnStateConnected
 }
 
 // update connection and trigger read and
@@ -428,7 +441,7 @@ func (c *Conn) read() {
 	defer c.Close()
 
 	var (
-		head []byte = make([]byte, 4)
+		head = make([]byte, 4)
 		body []byte
 
 		ln uint32
@@ -514,7 +527,7 @@ func (c *Conn) writeMsg(w io.Writer, body []byte) (terminate bool, err error) {
 		return // terminate everything
 	}
 
-	var head []byte = make([]byte, 4)
+	var head = make([]byte, 4)
 
 	binary.LittleEndian.PutUint32(head, uint32(len(body)))
 
@@ -639,7 +652,7 @@ DialLoop: // -------------------------------------------------------------------
 //                            an attached value                               //
 // ========================================================================== //
 
-// The Value returns value provided using SetValue method
+// Value returns value provided using SetValue method
 func (c *Conn) Value() interface{} {
 	c.vmx.Lock()
 	defer c.vmx.Unlock()
@@ -647,7 +660,7 @@ func (c *Conn) Value() interface{} {
 	return c.val
 }
 
-// The SetValue attach any value to the connection
+// SetValue attach any value to the connection
 func (c *Conn) SetValue(val interface{}) {
 	c.vmx.Lock()
 	defer c.vmx.Unlock()
@@ -729,6 +742,7 @@ func (c *Conn) Conn() net.Conn {
 //                                  close                                     //
 // ========================================================================== //
 
+// Close connection
 func (c *Conn) Close() (err error) {
 	c.closeo.Do(func() {
 		c.p.Debugf("closing %s...", c.address)

--- a/node/gnet/conn.go
+++ b/node/gnet/conn.go
@@ -35,8 +35,8 @@ func (c ConnState) String() string {
 	return fmt.Sprintf("ConnState<%d>", c)
 }
 
-// A Conn represents conenction. The Conn can has and can has
-// not underlying TCP conenction. The Conn recereates connection
+// A Conn represents connection. The Conn can has and can has
+// not underlying TCP connection. The Conn recereates connection
 // if it fails. This behaviour should be configures. There are
 // DialTimeout, RedialTimeout, MaxRedialTimeout and DialsLimit
 // configuration.Also, you can control dialing and redialing
@@ -46,7 +46,7 @@ func (c ConnState) String() string {
 // ConnStateDialing and ConnStateClosed. But the state can
 // be changed any time after. If the state is ConnStateClosed
 // then it will not be changed anymore. Use Clsoe method to
-// terminate conenction and wait until it release associated
+// terminate connection and wait until it release associated
 // resources (goroutines, TCP connection, buffers)
 type Conn struct {
 	address string // diaing address

--- a/node/gnet/conn_test.go
+++ b/node/gnet/conn_test.go
@@ -29,8 +29,8 @@ func pair() (l, d *Pool, lc, dc *Conn, err error) {
 		return
 	}
 	var (
-		lconf    Config     = newConfig("listener")
-		accepted chan *Conn = make(chan *Conn, 1)
+		lconf    = newConfig("listener")
+		accepted = make(chan *Conn, 1)
 	)
 	lconf.OnCreateConnection = func(c *Conn) {
 		select {

--- a/node/gnet/pool.go
+++ b/node/gnet/pool.go
@@ -103,6 +103,9 @@ func (p *Pool) release() {
 //                                  listeninng                                //
 // ========================================================================== //
 
+// Listen on given address. Only one listener allowed. The listener
+// never recreated. If it fails, you need to recreate entire Pool to
+// listen again
 func (p *Pool) Listen(address string) (err error) {
 	if p.isClosed() {
 		err = ErrClosed
@@ -262,7 +265,7 @@ func (p *Pool) Connections() (cs []*Conn) {
 	return
 }
 
-// Connections returns a connection by address
+// Connection returns a connection by address
 // or nil if connectios with given address doesn't exists
 func (p *Pool) Connection(address string) *Conn {
 	p.cmx.Lock()

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -12,7 +12,6 @@ import (
 	//"github.com/skycoin/skycoin/src/cipher"
 
 	"github.com/skycoin/cxo/node/gnet"
-	"github.com/skycoin/cxo/skyobject"
 )
 
 // timeout to fail slow opertions
@@ -22,6 +21,12 @@ var (
 	testDataDir      = filepath.Join(".", "test")
 	testServerDBPath = filepath.Join(testDataDir, "server.db")
 )
+
+func init() {
+	if !testing.Verbose() {
+		log.SetOutput(ioutil.Discard) // for RPC logs
+	}
+}
 
 func clean() {
 	os.RemoveAll(testDataDir)
@@ -39,6 +44,9 @@ func shouldPanic(t *testing.T) {
 func newNodeConfig(listen bool) (conf NodeConfig) {
 	conf = NewNodeConfig()
 	conf.Log.Debug = testing.Verbose()
+	if !testing.Verbose() {
+		conf.Log.Output = ioutil.Discard
+	}
 	conf.Listen = "127.0.0.1:0" // arbitrary assignment
 	conf.EnableListener = listen
 
@@ -48,23 +56,6 @@ func newNodeConfig(listen bool) (conf NodeConfig) {
 	conf.InMemoryDB = true
 	conf.DataDir = testDataDir
 	conf.DBPath = testServerDBPath
-	return
-}
-
-func newNode(conf NodeConfig) (s *Node, err error) {
-	s, err = newNodeReg(conf, nil)
-	return
-}
-
-func newNodeReg(conf NodeConfig, reg *skyobject.Registry) (s *Node, err error) {
-	if s, err = NewNodeReg(conf, reg); err != nil {
-		return
-	}
-	if !testing.Verbose() {
-		s.Logger.SetOutput(ioutil.Discard)
-		s.pool.Logger.SetOutput(ioutil.Discard)
-		log.SetOutput(ioutil.Discard) // RPC
-	}
 	return
 }
 
@@ -94,21 +85,12 @@ func newConnectedNodes(aconf, bconf NodeConfig) (a, b *Node,
 		}
 	}
 
-	if a, err = newNode(aconf); err != nil {
-		return
-	}
-	if err = a.Start(); err != nil {
-		a.Close()
+	if a, err = NewNode(aconf); err != nil {
 		return
 	}
 
-	if b, err = newNode(bconf); err != nil {
+	if b, err = NewNode(bconf); err != nil {
 		a.Close()
-		return
-	}
-	if err = b.Start(); err != nil {
-		a.Close()
-		b.Close()
 		return
 	}
 

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -41,8 +41,8 @@ func shouldPanic(t *testing.T) {
 // name for logs (empty for default)
 // memory - to use databas in memory (otherwise it will be ./test/test.db)
 // listening enabled by argument
-func newNodeConfig(listen bool) (conf NodeConfig) {
-	conf = NewNodeConfig()
+func newConfig(listen bool) (conf Config) {
+	conf = NewConfig()
 	conf.Log.Debug = testing.Verbose()
 	if !testing.Verbose() {
 		conf.Log.Output = ioutil.Discard
@@ -61,7 +61,7 @@ func newNodeConfig(listen bool) (conf NodeConfig) {
 
 // b - listener (listens anyway)
 // a - connects to b (can listen and can not)
-func newConnectedNodes(aconf, bconf NodeConfig) (a, b *Node,
+func newConnectedNodes(aconf, bconf Config) (a, b *Node,
 	ac, bc *gnet.Conn, err error) {
 
 	bconf.EnableListener = true

--- a/node/log/log.go
+++ b/node/log/log.go
@@ -13,9 +13,11 @@ const (
 	Debug  bool   = false
 )
 
+// A Config represents configurationf for logger
 type Config struct {
-	Prefix string
-	Debug  bool
+	Prefix string    // log prefix
+	Debug  bool      // show debug logs
+	Output io.Writer // provide an output
 }
 
 func NewConfig() (c Config) {
@@ -77,6 +79,18 @@ func NewLogger(prefix string, debug bool) Logger {
 	return &logger{
 		Logger: log.New(os.Stderr, prefix, log.Lshortfile|log.Ltime),
 		debug:  debug,
+	}
+}
+
+// NewLoggerByConfig create logger usinng given Config
+func NewLoggerByConfig(conf Config) Logger {
+	var out io.Writer = os.Stderr
+	if conf.Output != nil {
+		out = conf.Output
+	}
+	return &logger{
+		Logger: log.New(out, conf.Prefix, log.Lshortfile|log.Ltime),
+		debug:  conf.Debug,
 	}
 }
 

--- a/node/log/log.go
+++ b/node/log/log.go
@@ -8,9 +8,10 @@ import (
 	"os"
 )
 
+// defaults
 const (
-	Prefix string = ""
-	Debug  bool   = false
+	Prefix string = ""    // default prefix
+	Debug  bool   = false // don't show debug logs by default
 )
 
 // A Config represents configurationf for logger
@@ -20,12 +21,15 @@ type Config struct {
 	Output io.Writer // provide an output
 }
 
+// NewConfig returns Config with defautl values
 func NewConfig() (c Config) {
 	c.Prefix = Prefix
 	c.Debug = Debug
 	return
 }
 
+// FromFlags parses commandline flags. So, you need to call
+// flag.Parse after this method
 func (c *Config) FromFlags() {
 	flag.StringVar(&c.Prefix,
 		"log-prefix",

--- a/node/log/log_test.go
+++ b/node/log/log_test.go
@@ -17,7 +17,7 @@ func cleanLoggerOut(prefix string, debug bool) (l Logger, out *bytes.Buffer) {
 func TestNewLogger(t *testing.T) {
 	var l Logger
 	t.Run("prefix", func(t *testing.T) {
-		var prefix string = "prefix"
+		prefix := "prefix"
 		var out *bytes.Buffer
 		l, out = cleanLoggerOut(prefix, false)
 		l.Print()
@@ -89,7 +89,7 @@ func TestLogger_Debugf(t *testing.T) {
 }
 
 func TestLogger_SetDebug(t *testing.T) {
-	var l Logger = NewLogger("", false)
+	l := NewLogger("", false)
 	l.SetDebug(true)
 	if d := l.(*logger).debug; d != true {
 		t.Errorf("wrong debug flag: want true, got %#v", d)

--- a/node/log/log_test.go
+++ b/node/log/log_test.go
@@ -28,11 +28,11 @@ func TestNewLogger(t *testing.T) {
 	t.Run("debug", func(t *testing.T) {
 		l = NewLogger("", false)
 		if d := l.(*logger).debug; d != false {
-			t.Errorf("wrong debug flag: want false, got %q", d)
+			t.Errorf("wrong debug flag: want false, got %#v", d)
 		}
 		l = NewLogger("", true)
 		if d := l.(*logger).debug; d != true {
-			t.Errorf("wrong debug flag: want true, got %q", d)
+			t.Errorf("wrong debug flag: want true, got %#v", d)
 		}
 	})
 }
@@ -92,10 +92,10 @@ func TestLogger_SetDebug(t *testing.T) {
 	var l Logger = NewLogger("", false)
 	l.SetDebug(true)
 	if d := l.(*logger).debug; d != true {
-		t.Errorf("wrong debug flag: want true, got %q", d)
+		t.Errorf("wrong debug flag: want true, got %#v", d)
 	}
 	l.SetDebug(false)
 	if d := l.(*logger).debug; d != false {
-		t.Errorf("wrong debug flag: want false, got %q", d)
+		t.Errorf("wrong debug flag: want false, got %#v", d)
 	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -16,11 +16,19 @@ import (
 )
 
 var (
-	ErrTimeout              = errors.New("timeout")
+	// ErrTimeout occurs when a request that waits response tooks too long
+	ErrTimeout = errors.New("timeout")
+	// ErrSubscriptionRejected means that remote peer rejects our subscription
 	ErrSubscriptionRejected = errors.New("subscription rejected by remote peer")
-	ErrNilConnection        = errors.New("subscribe to nil connection")
-	ErrUnexpectedResponse   = errors.New("unexpected response")
-	ErrNonPublicPeer        = errors.New(
+	// ErrNilConnection means that you tries to subscribe or request list of
+	// feeds from a nil-connection
+	ErrNilConnection = errors.New("subscribe to nil connection")
+	// ErrUnexpectedResponse occurs if a remote peer sends any unexpected
+	// response for our request
+	ErrUnexpectedResponse = errors.New("unexpected response")
+	// ErrNonPublicPeer occurs if a remote peer can't give us list of
+	// feeds because it is not public
+	ErrNonPublicPeer = errors.New(
 		"request list of feeds from non-public peer")
 )
 
@@ -40,7 +48,7 @@ type Node struct {
 	src msgSource
 
 	// configuratios
-	conf NodeConfig
+	conf Config
 
 	// database
 	db data.DB
@@ -83,14 +91,14 @@ type Node struct {
 // NewNode creates new Node instnace using given
 // configurations. The functions creates database and
 // Container of skyobject instances internally
-func NewNode(sc NodeConfig) (s *Node, err error) {
+func NewNode(sc Config) (s *Node, err error) {
 	s, err = NewNodeReg(sc, nil)
 	return
 }
 
 // NewNodeReg creates new Node instance using given
 // skyobject.Registry to create container
-func NewNodeReg(sc NodeConfig, reg *skyobject.Registry) (s *Node,
+func NewNodeReg(sc Config, reg *skyobject.Registry) (s *Node,
 	err error) {
 
 	// database
@@ -189,7 +197,7 @@ func NewNodeReg(sc NodeConfig, reg *skyobject.Registry) (s *Node,
 // Start wes deprecated. This methods does nothing.
 //
 // Deprecated: just remove Start() invokation
-func (n *Node) Start() (_ error) {
+func (*Node) Start() (_ error) {
 	///
 	return
 }
@@ -326,7 +334,7 @@ func maxDuration(a, b time.Duration) time.Duration {
 func (s *Node) pingsLoop() {
 	defer s.await.Done()
 
-	var tk *time.Ticker = time.NewTicker(s.conf.PingInterval)
+	tk := time.NewTicker(s.conf.PingInterval)
 	defer tk.Stop()
 
 	for {
@@ -349,7 +357,7 @@ func (s *Node) pingsLoop() {
 func (s *Node) gcLoop() {
 	defer s.await.Done()
 
-	var tk *time.Ticker = time.NewTicker(s.conf.GCInterval)
+	tk := time.NewTicker(s.conf.GCInterval)
 	defer tk.Stop()
 
 	s.Debug("start GC loop ", s.conf.GCInterval)
@@ -444,8 +452,8 @@ func (s *Node) handleConnection(c *gnet.Conn) {
 	defer s.close(c)
 
 	var (
-		closed  <-chan struct{} = c.Closed()
-		receive <-chan []byte   = c.ReceiveQueue()
+		closed  = c.Closed()
+		receive = c.ReceiveQueue()
 
 		data []byte
 		msg  Msg
@@ -513,16 +521,16 @@ func (s *Node) handleSubscribeMsg(c *gnet.Conn, msg *SubscribeMsg) {
 	// (3) send  RejectSubscriptionMsg if the Node doesn't share feed
 	if accept, already := s.subscribeConn(c, msg.Feed); already == true {
 		// (2)
-		s.sendAcceptSubscriptionMsg(c, msg.Id(), msg.Feed)
+		s.sendAcceptSubscriptionMsg(c, msg.ID(), msg.Feed)
 		return
 	} else if accept == true {
 		// (1)
-		if s.sendAcceptSubscriptionMsg(c, msg.Id(), msg.Feed) {
+		if s.sendAcceptSubscriptionMsg(c, msg.ID(), msg.Feed) {
 			s.sendLastFullRoot(c, msg.Feed)
 		}
 		return
 	}
-	s.sendRejectSubscriptionMsg(c, msg.Id(), msg.Feed) // (3)
+	s.sendRejectSubscriptionMsg(c, msg.ID(), msg.Feed) // (3)
 }
 
 func (s *Node) handleUnsubscribeMsg(c *gnet.Conn, msg *UnsubscribeMsg) {
@@ -681,8 +689,8 @@ func (s *Node) handleRejectSubscriptionMsg(c *gnet.Conn,
 func (s *Node) sendToFeed(feed cipher.PubKey, msg Msg, except *gnet.Conn) {
 
 	var (
-		data []byte = Encode(msg)            // encode once
-		name string = fmt.Sprintf("%T", msg) // name for debug logs
+		data = Encode(msg)            // encode once
+		name = fmt.Sprintf("%T", msg) // name for debug logs
 	)
 
 	s.fmx.RLock()
@@ -805,7 +813,7 @@ func (s *Node) handleRegistryMsg(c *gnet.Conn, msg *RegistryMsg) {
 	s.rmx.Lock()
 	defer s.rmx.Unlock()
 
-	var i int = 0 // index for deleting
+	var i int // index for deleting
 	for _, fl := range s.roots {
 
 		if fl.root.RegistryReference() == reg.Reference() {
@@ -873,7 +881,7 @@ func (s *Node) handleDataMsg(c *gnet.Conn, msg *DataMsg) {
 	s.so.Set(hash, msg.Data) // save
 
 	// check filling
-	var i int = 0 // index for deleting
+	var i int // index for deleting
 	for _, fl := range s.roots {
 
 		if fl.await == hash {
@@ -920,9 +928,9 @@ func (s *Node) handleRequestListOfFeedsMsg(c *gnet.Conn,
 	x *RequestListOfFeedsMsg) {
 
 	if s.conf.PublicServer == true {
-		s.sendListOfFeedsMsg(c, x.Id(), s.Feeds())
+		s.sendListOfFeedsMsg(c, x.ID(), s.Feeds())
 	} else {
-		s.sendNonPublicServerMsg(c, x.Id()) // reject
+		s.sendNonPublicServerMsg(c, x.ID()) // reject
 	}
 }
 
@@ -1015,7 +1023,7 @@ func (s *Node) handleMsg(c *gnet.Conn, msg Msg) {
 // Public methods of the Node
 //
 
-// A Pool returns underlying *gnet.Pool.
+// Pool returns underlying *gnet.Pool.
 // It returns nil if the Node is not started
 // yet. Use methods of this Pool to manipulate
 // connections: Dial, Connection, Connections,
@@ -1066,7 +1074,7 @@ func (s *Node) isAlreadySusbcribed(c *gnet.Conn,
 
 // Subscribe to given feed. If given connection is nil, then this subscription
 // is local. Otherwise, it subscribes to a remote peer. To handle result use
-// (NodeConfig).OnAcceptSubsctiption and OnDeniedSubscription callbacks. The
+// (Config).OnAcceptSubsctiption and OnDeniedSubscription callbacks. The
 // connection must be from the gnet.Pool of the Node. To subscribe to the same
 // feed of many remote peers call the method many times for every connection
 // you want. To make the server subscribed to a feed (even if it is not
@@ -1086,7 +1094,7 @@ func (s *Node) Subscribe(c *gnet.Conn, feed cipher.PubKey) {
 	//
 	// lock: s.fmx Lock/Unlock
 	//
-	var already bool = s.addFeed(feed)
+	already := s.addFeed(feed)
 	// just return if we don't want to subscribe to feed of a remote peer
 	if c == nil {
 		return
@@ -1130,7 +1138,7 @@ func (s *Node) deleteFeedFromFilling(feed cipher.PubKey) {
 	s.rmx.Lock()
 	defer s.rmx.Unlock()
 
-	var i int = 0
+	var i int
 	for _, fl := range s.roots {
 		if fl.root.Pub() == feed {
 			continue // delete
@@ -1162,9 +1170,9 @@ func (s *Node) deleteFeed(feed cipher.PubKey) (cs map[*gnet.Conn]struct{}) {
 func (s *Node) unsubscribe(feed cipher.PubKey) {
 	// we can't use sendToFeed here
 	var (
-		msg   Msg    = s.src.NewUnsubscribeMsg(feed)
-		unsub []byte = Encode(msg)
-		name         = fmt.Sprintf("%T", msg)
+		msg   Msg = s.src.NewUnsubscribeMsg(feed)
+		unsub     = Encode(msg)
+		name      = fmt.Sprintf("%T", msg)
 	)
 	for peer := range s.deleteFeed(feed) {
 		s.sendEncodedMessage(peer, name, unsub)
@@ -1278,7 +1286,7 @@ func (s *Node) Feeds() (fs []cipher.PubKey) {
 	return
 }
 
-// Quititng returns cahnnel that closed
+// Quiting returns cahnnel that closed
 // when the Node closed
 func (s *Node) Quiting() <-chan struct{} {
 	return s.done // when quit done
@@ -1311,7 +1319,7 @@ func (s *Node) sendMsgAndWaitForResponse(c *gnet.Conn,
 	var (
 		tm *time.Timer
 		tc <-chan time.Time
-		rc chan Msg = make(chan Msg, 1) // don't block sender
+		rc = make(chan Msg, 1) // don't block sender
 	)
 
 	if timeout > 0 {
@@ -1320,8 +1328,8 @@ func (s *Node) sendMsgAndWaitForResponse(c *gnet.Conn,
 		tc = tm.C
 	}
 
-	s.addWaitingForResponse(msg.Id(), rc)
-	defer s.takeWaitingForResponse(msg.Id())
+	s.addWaitingForResponse(msg.ID(), rc)
+	defer s.takeWaitingForResponse(msg.ID())
 
 	s.sendMessage(c, msg)
 
@@ -1335,7 +1343,7 @@ func (s *Node) sendMsgAndWaitForResponse(c *gnet.Conn,
 
 // SubscribeResponse is similar to subscribe but it requires non-nil connection
 // and waits for reply from remote peer. It waits for response
-// NodeConfig.ResponseTimeout. Unlike Subsribe it can subscribe twice or
+// Config.ResponseTimeout. Unlike Subsribe it can subscribe twice or
 // many times sending mesages and waiting response
 func (s *Node) SubscribeResponse(c *gnet.Conn, feed cipher.PubKey) error {
 
@@ -1442,9 +1450,9 @@ func (s *Node) ListOfFeedsResponseTimeout(c *gnet.Conn,
 
 // RPCAddress returns address of RPC listener or an empty
 // stirng if disabled
-func (n *Node) RPCAddress() (address string) {
-	if n.rpc != nil {
-		address = n.rpc.Address()
+func (s *Node) RPCAddress() (address string) {
+	if s.rpc != nil {
+		address = s.rpc.Address()
 	}
 	return
 }

--- a/node/node.go
+++ b/node/node.go
@@ -118,7 +118,7 @@ func NewNodeReg(sc NodeConfig, reg *skyobject.Registry) (s *Node,
 
 	s = new(Node)
 
-	s.Logger = log.NewLogger(sc.Log.Prefix, sc.Log.Debug)
+	s.Logger = log.NewLoggerByConfig(sc.Log)
 	s.conf = sc
 
 	s.db = db
@@ -179,11 +179,22 @@ func NewNodeReg(sc NodeConfig, reg *skyobject.Registry) (s *Node,
 	s.quit = make(chan struct{})
 	s.done = make(chan struct{})
 
+	if err = s.start(); err != nil {
+		s.Close()
+		s = nil
+	}
 	return
 }
 
-// Start the Node
-func (s *Node) Start() (err error) {
+// Start wes deprecated. This methods does nothing.
+//
+// Deprecated: just remove Start() invokation
+func (n *Node) Start() (_ error) {
+	///
+	return
+}
+
+func (s *Node) start() (err error) {
 	s.Debugf(`starting node:
     data dir:             %s
 

--- a/node/node.go
+++ b/node/node.go
@@ -373,7 +373,7 @@ func (s *Node) sendEncodedMessage(c *gnet.Conn, name string,
 		ok = true
 	case <-c.Closed():
 	default:
-		s.Print("[ERR] %s send queue full", c.Address())
+		s.Printf("[ERR] %s send queue full", c.Address())
 		c.Close()
 	}
 	return

--- a/node/node_benchmark_test.go
+++ b/node/node_benchmark_test.go
@@ -25,14 +25,14 @@ ok      github.com/logrusorgru/cxo/node 73.241s
 // TODO: DRY
 //
 
-func benchmarkNode_srcDst_emptyRootsMemory(b *testing.B) {
+func benchmarkNodeSrcDstEmptyRootsMemory(b *testing.B) {
 
 	// prepare
 	reg := skyobject.NewRegistry()
 	reg.Register("bench.User", User{})
 
-	sconf := newNodeConfig(false)
-	dconf := newNodeConfig(true)
+	sconf := newConfig(false)
+	dconf := newConfig(true)
 
 	filled := make(chan struct{})
 	dconf.OnRootFilled = func(*Root) {
@@ -102,7 +102,7 @@ func benchmarkNode_srcDst_emptyRootsMemory(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func benchmarkNode_srcDst_emptyRootsBoltDB(b *testing.B) {
+func benchmarkNodeSrcDstEmptyRootsBoltDB(b *testing.B) {
 
 	defer clean()
 
@@ -111,11 +111,11 @@ func benchmarkNode_srcDst_emptyRootsBoltDB(b *testing.B) {
 
 	reg.Register("bench.User", User{})
 
-	sconf := newNodeConfig(false)
+	sconf := newConfig(false)
 	sconf.InMemoryDB = false
 	sconf.DBPath = sconf.DBPath + ".source"
 
-	dconf := newNodeConfig(true)
+	dconf := newConfig(true)
 	dconf.InMemoryDB = false
 	dconf.DBPath = dconf.DBPath + ".destination"
 
@@ -189,21 +189,21 @@ func benchmarkNode_srcDst_emptyRootsBoltDB(b *testing.B) {
 
 func BenchmarkNode_srcDst(b *testing.B) {
 
-	b.Run("empty roots memory", benchmarkNode_srcDst_emptyRootsMemory)
-	b.Run("empty roots boltdb", benchmarkNode_srcDst_emptyRootsBoltDB)
+	b.Run("empty roots memory", benchmarkNodeSrcDstEmptyRootsMemory)
+	b.Run("empty roots boltdb", benchmarkNodeSrcDstEmptyRootsBoltDB)
 
 }
 
-func benchmarkNode_passThrough_emptyRootsMemory(b *testing.B) {
+func benchmarkNodePassThroughEmptyRootsMemory(b *testing.B) {
 
 	// prepare
 
 	reg := skyobject.NewRegistry()
 	reg.Register("bench.User", User{})
 
-	sconf := newNodeConfig(false)
-	pconf := newNodeConfig(true)
-	dconf := newNodeConfig(false)
+	sconf := newConfig(false)
+	pconf := newConfig(true)
+	dconf := newConfig(false)
 
 	filled := make(chan struct{})
 	dconf.OnRootFilled = func(*Root) {
@@ -306,7 +306,7 @@ func benchmarkNode_passThrough_emptyRootsMemory(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func benchmarkNode_passThrough_emptyRootsBoltDB(b *testing.B) {
+func benchmarkNodePassThroughEmptyRootsBoltDB(b *testing.B) {
 
 	defer clean()
 
@@ -315,13 +315,13 @@ func benchmarkNode_passThrough_emptyRootsBoltDB(b *testing.B) {
 	reg := skyobject.NewRegistry()
 	reg.Register("bench.User", User{})
 
-	sconf := newNodeConfig(false)
+	sconf := newConfig(false)
 	sconf.InMemoryDB = false
 	sconf.DBPath = sconf.DBPath + ".source"
-	pconf := newNodeConfig(true)
+	pconf := newConfig(true)
 	pconf.InMemoryDB = false
 	pconf.DBPath = pconf.DBPath + ".pipe"
-	dconf := newNodeConfig(false)
+	dconf := newConfig(false)
 	dconf.InMemoryDB = false
 	dconf.DBPath = dconf.DBPath + ".destination"
 
@@ -428,7 +428,7 @@ func benchmarkNode_passThrough_emptyRootsBoltDB(b *testing.B) {
 
 func BenchmarkNode_passThrough(b *testing.B) {
 
-	b.Run("empty roots memory", benchmarkNode_passThrough_emptyRootsMemory)
-	b.Run("empty roots boltdb", benchmarkNode_passThrough_emptyRootsBoltDB)
+	b.Run("empty roots memory", benchmarkNodePassThroughEmptyRootsMemory)
+	b.Run("empty roots boltdb", benchmarkNodePassThroughEmptyRootsBoltDB)
 
 }

--- a/node/node_benchmark_test.go
+++ b/node/node_benchmark_test.go
@@ -25,444 +25,410 @@ ok      github.com/logrusorgru/cxo/node 73.241s
 // TODO: DRY
 //
 
-func BenchmarkNode_srcDst(b *testing.B) {
+func benchmarkNode_srcDst_emptyRootsMemory(b *testing.B) {
 
-	// types
+	// prepare
+	reg := skyobject.NewRegistry()
+	reg.Register("bench.User", User{})
 
-	type User struct {
-		Name string
-		Age  uint32
+	sconf := newNodeConfig(false)
+	dconf := newNodeConfig(true)
+
+	filled := make(chan struct{})
+	dconf.OnRootFilled = func(*Root) {
+		filled <- struct{}{}
 	}
 
-	b.Run("empty roots memory", func(b *testing.B) {
+	s, d, sc, _, err := newConnectedNodes(sconf, dconf)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer s.Close()
+	defer d.Close()
 
-		// prepare
-		reg := skyobject.NewRegistry()
+	pk, sk := cipher.GenerateKeyPair()
 
-		reg.Register("bench.User", User{})
+	d.Subscribe(nil, pk)
+	if err := s.SubscribeResponse(sc, pk); err != nil {
+		b.Error(err)
+		return
+	}
 
-		sconf := newNodeConfig(false)
+	// add registry and create first root
+	cnt := s.Container()
 
-		dconf := newNodeConfig(true)
+	var root *Root
 
-		filled := make(chan struct{})
-		dconf.OnRootFilled = func(*Root) {
-			filled <- struct{}{}
-		}
-
-		s, d, sc, _, err := newConnectedNodes(sconf, dconf)
+	// becasu we're not using "core registry" we need be sure that
+	// GC doesn't cleans our registry until we create first root object
+	cnt.LockGC()
+	{
+		cnt.AddRegistry(reg)
+		root, err = cnt.NewRootReg(pk, sk, reg.Reference())
 		if err != nil {
-			b.Fatal(err)
+			cnt.UnlockGC()
+			b.Error(err)
+			return
 		}
-		defer s.Close()
-		defer d.Close()
-
-		pk, sk := cipher.GenerateKeyPair()
-
-		d.Subscribe(nil, pk)
-		if err := s.SubscribeResponse(sc, pk); err != nil {
+		if _, err = root.Touch(); err != nil { // crete first root
+			cnt.UnlockGC()
 			b.Error(err)
 			return
 		}
 
-		// add registry and create first root
-		cnt := s.Container()
+	}
+	cnt.UnlockGC()
 
-		var root *Root
+	select {
+	case <-filled:
+	case <-time.After(TM * 10):
+		b.Error("slow or missing")
+		return
+	}
 
-		// becasu we're not using "core registry" we need be sure that
-		// GC doesn't cleans our registry until we create first root object
-		cnt.LockGC()
-		{
-			cnt.AddRegistry(reg)
-			root, err = cnt.NewRootReg(pk, sk, reg.Reference())
-			if err != nil {
-				cnt.UnlockGC()
-				b.Error(err)
-				return
-			}
-			if _, err = root.Touch(); err != nil { // crete first root
-				cnt.UnlockGC()
-				b.Error(err)
-				return
-			}
-
-		}
-		cnt.UnlockGC()
-
-		select {
-		case <-filled:
-		case <-time.After(TM * 10):
-			b.Error("slow or missing")
+	// run
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// update
+		if _, err = root.Touch(); err != nil {
+			b.Error(err)
 			return
 		}
+		// receive filled
+		<-filled
+	}
 
-		// run
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			// update
-			if _, err = root.Touch(); err != nil {
-				b.Error(err)
-				return
-			}
-			// receive filled
-			<-filled
-		}
+	// fini
+	b.ReportAllocs()
+}
 
-		// fini
-		b.ReportAllocs()
-	})
+func benchmarkNode_srcDst_emptyRootsBoltDB(b *testing.B) {
 
-	b.Run("empty roots boltdb", func(b *testing.B) {
+	defer clean()
 
-		defer clean()
+	// prepare
+	reg := skyobject.NewRegistry()
 
-		// prepare
-		reg := skyobject.NewRegistry()
+	reg.Register("bench.User", User{})
 
-		reg.Register("bench.User", User{})
+	sconf := newNodeConfig(false)
+	sconf.InMemoryDB = false
+	sconf.DBPath = sconf.DBPath + ".source"
 
-		sconf := newNodeConfig(false)
-		sconf.InMemoryDB = false
-		sconf.DBPath = sconf.DBPath + ".source"
+	dconf := newNodeConfig(true)
+	dconf.InMemoryDB = false
+	dconf.DBPath = dconf.DBPath + ".destination"
 
-		dconf := newNodeConfig(true)
-		dconf.InMemoryDB = false
-		dconf.DBPath = dconf.DBPath + ".destination"
+	filled := make(chan struct{})
+	dconf.OnRootFilled = func(*Root) {
+		filled <- struct{}{}
+	}
 
-		filled := make(chan struct{})
-		dconf.OnRootFilled = func(*Root) {
-			filled <- struct{}{}
-		}
+	s, d, sc, _, err := newConnectedNodes(sconf, dconf)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer s.Close()
+	defer d.Close()
 
-		s, d, sc, _, err := newConnectedNodes(sconf, dconf)
+	pk, sk := cipher.GenerateKeyPair()
+
+	d.Subscribe(nil, pk)
+	if err := s.SubscribeResponse(sc, pk); err != nil {
+		b.Error(err)
+		return
+	}
+
+	// add registry and create first root
+	cnt := s.Container()
+
+	var root *Root
+
+	// becasu we're not using "core registry" we need be sure that
+	// GC doesn't cleans our registry until we create first root object
+	cnt.LockGC()
+	{
+		cnt.AddRegistry(reg)
+		root, err = cnt.NewRootReg(pk, sk, reg.Reference())
 		if err != nil {
-			b.Fatal(err)
+			cnt.UnlockGC()
+			b.Error(err)
+			return
 		}
-		defer s.Close()
-		defer d.Close()
-
-		pk, sk := cipher.GenerateKeyPair()
-
-		d.Subscribe(nil, pk)
-		if err := s.SubscribeResponse(sc, pk); err != nil {
+		if _, err = root.Touch(); err != nil { // crete first root
+			cnt.UnlockGC()
 			b.Error(err)
 			return
 		}
 
-		// add registry and create first root
-		cnt := s.Container()
+	}
+	cnt.UnlockGC()
 
-		var root *Root
+	select {
+	case <-filled:
+	case <-time.After(TM * 10):
+		b.Error("slow or missing")
+		return
+	}
 
-		// becasu we're not using "core registry" we need be sure that
-		// GC doesn't cleans our registry until we create first root object
-		cnt.LockGC()
-		{
-			cnt.AddRegistry(reg)
-			root, err = cnt.NewRootReg(pk, sk, reg.Reference())
-			if err != nil {
-				cnt.UnlockGC()
-				b.Error(err)
-				return
-			}
-			if _, err = root.Touch(); err != nil { // crete first root
-				cnt.UnlockGC()
-				b.Error(err)
-				return
-			}
-
+	// run
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// update
+		if _, err = root.Touch(); err != nil {
+			b.Error(err)
+			return
 		}
-		cnt.UnlockGC()
+		// receive filled
+		<-filled
+	}
 
-		select {
-		case <-filled:
-		case <-time.After(TM * 10):
-			b.Error("slow or missing")
+	// fini
+	b.ReportAllocs()
+}
+
+func BenchmarkNode_srcDst(b *testing.B) {
+
+	b.Run("empty roots memory", benchmarkNode_srcDst_emptyRootsMemory)
+	b.Run("empty roots boltdb", benchmarkNode_srcDst_emptyRootsBoltDB)
+
+}
+
+func benchmarkNode_passThrough_emptyRootsMemory(b *testing.B) {
+
+	// prepare
+
+	reg := skyobject.NewRegistry()
+	reg.Register("bench.User", User{})
+
+	sconf := newNodeConfig(false)
+	pconf := newNodeConfig(true)
+	dconf := newNodeConfig(false)
+
+	filled := make(chan struct{})
+	dconf.OnRootFilled = func(*Root) {
+		filled <- struct{}{}
+	}
+
+	// source
+	src, err := NewNode(sconf)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	defer src.Close()
+	// pipe
+	pipe, err := NewNode(pconf)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	defer pipe.Close()
+	// destination
+	dst, err := NewNode(dconf)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	defer dst.Close()
+
+	// source->pipe
+	sc, err := src.Pool().Dial(pipe.Pool().Address())
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	// destination->pipe
+	dc, err := dst.Pool().Dial(pipe.Pool().Address())
+	if err != nil {
+		b.Error(err)
+		return
+	}
+
+	pk, sk := cipher.GenerateKeyPair()
+
+	// subcribe
+	pipe.Subscribe(nil, pk)
+	if err := src.SubscribeResponse(sc, pk); err != nil {
+		b.Error(err)
+		return
+	}
+	if err := dst.SubscribeResponse(dc, pk); err != nil {
+		b.Error(err)
+		return
+	}
+
+	// add registry and create first root
+	cnt := src.Container()
+
+	var root *Root
+
+	// becasu we're not using "core registry" we need be sure that
+	// GC doesn't cleans our registry until we create first root object
+	cnt.LockGC()
+	{
+		cnt.AddRegistry(reg)
+		root, err = cnt.NewRootReg(pk, sk, reg.Reference())
+		if err != nil {
+			cnt.UnlockGC()
+			b.Error(err)
+			return
+		}
+		if _, err = root.Touch(); err != nil { // crete first root
+			cnt.UnlockGC()
+			b.Error(err)
 			return
 		}
 
-		// run
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			// update
-			if _, err = root.Touch(); err != nil {
-				b.Error(err)
-				return
-			}
-			// receive filled
-			<-filled
+	}
+	cnt.UnlockGC()
+
+	select {
+	case <-filled:
+	case <-time.After(TM * 10):
+		b.Error("slow or missing")
+		return
+	}
+
+	// run
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// update
+		if _, err = root.Touch(); err != nil {
+			b.Error(err)
+			return
+		}
+		// receive filled
+		<-filled
+	}
+
+	// fini
+	b.ReportAllocs()
+}
+
+func benchmarkNode_passThrough_emptyRootsBoltDB(b *testing.B) {
+
+	defer clean()
+
+	// prepare
+
+	reg := skyobject.NewRegistry()
+	reg.Register("bench.User", User{})
+
+	sconf := newNodeConfig(false)
+	sconf.InMemoryDB = false
+	sconf.DBPath = sconf.DBPath + ".source"
+	pconf := newNodeConfig(true)
+	pconf.InMemoryDB = false
+	pconf.DBPath = pconf.DBPath + ".pipe"
+	dconf := newNodeConfig(false)
+	dconf.InMemoryDB = false
+	dconf.DBPath = dconf.DBPath + ".destination"
+
+	filled := make(chan struct{})
+	dconf.OnRootFilled = func(*Root) {
+		filled <- struct{}{}
+	}
+
+	// source
+	src, err := NewNode(sconf)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	defer src.Close()
+	// pipe
+	pipe, err := NewNode(pconf)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	defer pipe.Close()
+	// destination
+	dst, err := NewNode(dconf)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	defer dst.Close()
+
+	// source->pipe
+	sc, err := src.Pool().Dial(pipe.Pool().Address())
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	// destination->pipe
+	dc, err := dst.Pool().Dial(pipe.Pool().Address())
+	if err != nil {
+		b.Error(err)
+		return
+	}
+
+	pk, sk := cipher.GenerateKeyPair()
+
+	// subcribe
+	pipe.Subscribe(nil, pk)
+	if err := src.SubscribeResponse(sc, pk); err != nil {
+		b.Error(err)
+		return
+	}
+	if err := dst.SubscribeResponse(dc, pk); err != nil {
+		b.Error(err)
+		return
+	}
+
+	// add registry and create first root
+	cnt := src.Container()
+
+	var root *Root
+
+	// becasu we're not using "core registry" we need be sure that
+	// GC doesn't cleans our registry until we create first root object
+	cnt.LockGC()
+	{
+		cnt.AddRegistry(reg)
+		root, err = cnt.NewRootReg(pk, sk, reg.Reference())
+		if err != nil {
+			cnt.UnlockGC()
+			b.Error(err)
+			return
+		}
+		if _, err = root.Touch(); err != nil { // crete first root
+			cnt.UnlockGC()
+			b.Error(err)
+			return
 		}
 
-		// fini
-		b.ReportAllocs()
-	})
+	}
+	cnt.UnlockGC()
 
+	select {
+	case <-filled:
+	case <-time.After(TM * 10):
+		b.Error("slow or missing")
+		return
+	}
+
+	// run
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// update
+		if _, err = root.Touch(); err != nil {
+			b.Error(err)
+			return
+		}
+		// receive filled
+		<-filled
+	}
+
+	// fini
+	b.ReportAllocs()
 }
 
 func BenchmarkNode_passThrough(b *testing.B) {
 
-	// types
-
-	type User struct {
-		Name string
-		Age  uint32
-	}
-
-	b.Run("empty roots memory", func(b *testing.B) {
-
-		// prepare
-
-		reg := skyobject.NewRegistry()
-		reg.Register("bench.User", User{})
-
-		sconf := newNodeConfig(false)
-		pconf := newNodeConfig(true)
-		dconf := newNodeConfig(false)
-
-		filled := make(chan struct{})
-		dconf.OnRootFilled = func(*Root) {
-			filled <- struct{}{}
-		}
-
-		// source
-		src, err := newNode(sconf)
-		if err != nil {
-			b.Error(err)
-			return
-		}
-		defer src.Close()
-		if err := src.Start(); err != nil {
-			b.Error(err)
-			return
-		}
-		// pipe
-		pipe, err := newNode(pconf)
-		if err != nil {
-			b.Error(err)
-			return
-		}
-		defer pipe.Close()
-		if err := pipe.Start(); err != nil {
-			b.Error(err)
-			return
-		}
-		// destination
-		dst, err := newNode(dconf)
-		if err != nil {
-			b.Error(err)
-			return
-		}
-		defer dst.Close()
-		if err := dst.Start(); err != nil {
-			b.Error(err)
-			return
-		}
-
-		// source->pipe
-		sc, err := src.Pool().Dial(pipe.Pool().Address())
-		if err != nil {
-			b.Error(err)
-			return
-		}
-		// destination->pipe
-		dc, err := dst.Pool().Dial(pipe.Pool().Address())
-		if err != nil {
-			b.Error(err)
-			return
-		}
-
-		pk, sk := cipher.GenerateKeyPair()
-
-		// subcribe
-		pipe.Subscribe(nil, pk)
-		if err := src.SubscribeResponse(sc, pk); err != nil {
-			b.Error(err)
-			return
-		}
-		if err := dst.SubscribeResponse(dc, pk); err != nil {
-			b.Error(err)
-			return
-		}
-
-		// add registry and create first root
-		cnt := src.Container()
-
-		var root *Root
-
-		// becasu we're not using "core registry" we need be sure that
-		// GC doesn't cleans our registry until we create first root object
-		cnt.LockGC()
-		{
-			cnt.AddRegistry(reg)
-			root, err = cnt.NewRootReg(pk, sk, reg.Reference())
-			if err != nil {
-				cnt.UnlockGC()
-				b.Error(err)
-				return
-			}
-			if _, err = root.Touch(); err != nil { // crete first root
-				cnt.UnlockGC()
-				b.Error(err)
-				return
-			}
-
-		}
-		cnt.UnlockGC()
-
-		select {
-		case <-filled:
-		case <-time.After(TM * 10):
-			b.Error("slow or missing")
-			return
-		}
-
-		// run
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			// update
-			if _, err = root.Touch(); err != nil {
-				b.Error(err)
-				return
-			}
-			// receive filled
-			<-filled
-		}
-
-		// fini
-		b.ReportAllocs()
-	})
-
-	b.Run("empty roots boltdb", func(b *testing.B) {
-
-		defer clean()
-
-		// prepare
-
-		reg := skyobject.NewRegistry()
-		reg.Register("bench.User", User{})
-
-		sconf := newNodeConfig(false)
-		sconf.InMemoryDB = false
-		sconf.DBPath = sconf.DBPath + ".source"
-		pconf := newNodeConfig(true)
-		pconf.InMemoryDB = false
-		pconf.DBPath = pconf.DBPath + ".pipe"
-		dconf := newNodeConfig(false)
-		dconf.InMemoryDB = false
-		dconf.DBPath = dconf.DBPath + ".destination"
-
-		filled := make(chan struct{})
-		dconf.OnRootFilled = func(*Root) {
-			filled <- struct{}{}
-		}
-
-		// source
-		src, err := newNode(sconf)
-		if err != nil {
-			b.Error(err)
-			return
-		}
-		defer src.Close()
-		if err := src.Start(); err != nil {
-			b.Error(err)
-			return
-		}
-		// pipe
-		pipe, err := newNode(pconf)
-		if err != nil {
-			b.Error(err)
-			return
-		}
-		defer pipe.Close()
-		if err := pipe.Start(); err != nil {
-			b.Error(err)
-			return
-		}
-		// destination
-		dst, err := newNode(dconf)
-		if err != nil {
-			b.Error(err)
-			return
-		}
-		defer dst.Close()
-		if err := dst.Start(); err != nil {
-			b.Error(err)
-			return
-		}
-
-		// source->pipe
-		sc, err := src.Pool().Dial(pipe.Pool().Address())
-		if err != nil {
-			b.Error(err)
-			return
-		}
-		// destination->pipe
-		dc, err := dst.Pool().Dial(pipe.Pool().Address())
-		if err != nil {
-			b.Error(err)
-			return
-		}
-
-		pk, sk := cipher.GenerateKeyPair()
-
-		// subcribe
-		pipe.Subscribe(nil, pk)
-		if err := src.SubscribeResponse(sc, pk); err != nil {
-			b.Error(err)
-			return
-		}
-		if err := dst.SubscribeResponse(dc, pk); err != nil {
-			b.Error(err)
-			return
-		}
-
-		// add registry and create first root
-		cnt := src.Container()
-
-		var root *Root
-
-		// becasu we're not using "core registry" we need be sure that
-		// GC doesn't cleans our registry until we create first root object
-		cnt.LockGC()
-		{
-			cnt.AddRegistry(reg)
-			root, err = cnt.NewRootReg(pk, sk, reg.Reference())
-			if err != nil {
-				cnt.UnlockGC()
-				b.Error(err)
-				return
-			}
-			if _, err = root.Touch(); err != nil { // crete first root
-				cnt.UnlockGC()
-				b.Error(err)
-				return
-			}
-
-		}
-		cnt.UnlockGC()
-
-		select {
-		case <-filled:
-		case <-time.After(TM * 10):
-			b.Error("slow or missing")
-			return
-		}
-
-		// run
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			// update
-			if _, err = root.Touch(); err != nil {
-				b.Error(err)
-				return
-			}
-			// receive filled
-			<-filled
-		}
-
-		// fini
-		b.ReportAllocs()
-	})
+	b.Run("empty roots memory", benchmarkNode_passThrough_emptyRootsMemory)
+	b.Run("empty roots boltdb", benchmarkNode_passThrough_emptyRootsBoltDB)
 
 }

--- a/node/node_examples_test.go
+++ b/node/node_examples_test.go
@@ -25,10 +25,7 @@ func ExampleNewNode() {
 	}
 	defer node.Close()
 
-	if err := node.Start(); err != nil {
-		// handle error
-		return // don't call Fatal, panic, etc, because of BoltDB
-	}
+	// don't call Fatal, panic, etc, because of BoltDB
 
 	// stuff here
 }
@@ -56,10 +53,7 @@ func ExampleNewNodeReg() {
 	}
 	defer node.Close()
 
-	if err := node.Start(); err != nil {
-		// handle error
-		return // don't call Fatal, panic, etc, because of BoltDB
-	}
+	// don't call Fatal, panic, etc, because of BoltDB
 
 	// stuff here
 }
@@ -74,11 +68,6 @@ func ExampleNode_Pool() {
 		// handle error
 	}
 	defer node.Close()
-
-	if err := node.Start(); err != nil {
-		// handle error
-		return
-	}
 
 	pool := node.Pool()
 
@@ -134,11 +123,6 @@ func ExampleNode_Subscribe() {
 	}
 	defer node.Close()
 
-	if err := node.Start(); err != nil {
-		// handle error
-		return
-	}
-
 	// make the node subscribed to feed Y
 
 	node.Subscribe(nil, Y)
@@ -170,11 +154,6 @@ func ExampleNode_Unsubscribe() {
 		// handle error
 	}
 	defer node.Close()
-
-	if err := node.Start(); err != nil {
-		// handle error
-		return
-	}
 
 	// make the node subscribed to feed Y
 
@@ -224,11 +203,6 @@ func ExampleNode_Feeds() {
 	}
 	defer node.Close()
 
-	if err := node.Start(); err != nil {
-		// handle error
-		return
-	}
-
 	// check out feed we already subscribed to
 
 	if len(node.Feeds()) != 0 {
@@ -263,11 +237,6 @@ func ExampleNode_Quiting() {
 	}
 	defer node.Close()
 
-	if err := node.Start(); err != nil {
-		// handle error
-		return
-	}
-
 	go func() {
 		defer node.Close()
 
@@ -298,11 +267,6 @@ func ExampleNode_SubscribeResponse() {
 	}
 	defer node.Close()
 
-	if err := node.Start(); err != nil {
-		// handle error
-		return
-	}
-
 	// connect to remote peer
 
 	peer, err := node.Pool().Dial("127.0.0.1:8998")
@@ -328,11 +292,6 @@ func ExampleNode_ListOfFeedsResponse() {
 		// handle error
 	}
 	defer node.Close()
-
-	if err := node.Start(); err != nil {
-		// handle error
-		return
-	}
 
 	// connect to remote public peer
 

--- a/node/node_examples_test.go
+++ b/node/node_examples_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/skycoin/cxo/skyobject"
 )
 
-func getConfig() (c NodeConfig) {
-	c = NewNodeConfig()
+func getConfig() (c Config) {
+	c = NewConfig()
 	c.InMemoryDB = true // use database in memory for examples
 	return
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 func TestNewNode(t *testing.T) {
-	// NewNode(sc NodeConfig) (s *Node, err error)
+	// NewNode(sc Config) (s *Node, err error)
 
 	// registry must be nil
 	t.Run("registry", func(t *testing.T) {
-		s, err := NewNode(newNodeConfig(false))
+		s, err := NewNode(newConfig(false))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -40,7 +40,7 @@ func TestNewNode(t *testing.T) {
 	t.Run("memory db", func(t *testing.T) {
 		clean()
 
-		conf := newNodeConfig(false) // in-memory
+		conf := newConfig(false) // in-memory
 
 		s, err := NewNode(conf)
 		if err != nil {
@@ -67,7 +67,7 @@ func TestNewNode(t *testing.T) {
 	t.Run("data dir", func(t *testing.T) {
 		clean()
 
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 		conf.InMemoryDB = false
 
 		s, err := NewNode(conf)
@@ -89,7 +89,7 @@ func TestNewNode(t *testing.T) {
 	t.Run("dbpath", func(t *testing.T) {
 		clean()
 
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 		conf.InMemoryDB = false
 		conf.DBPath = filepath.Join(testDataDir, "another.db")
 
@@ -117,13 +117,13 @@ func TestNewNode(t *testing.T) {
 }
 
 func TestNewNodeReg(t *testing.T) {
-	// NewNodeReg(sc NodeConfig, reg *skyobject.Registry) (s *Node, err error)
+	// NewNodeReg(sc Config, reg *skyobject.Registry) (s *Node, err error)
 
 	// registry must be the same
 	t.Run("registry", func(t *testing.T) {
 		reg := skyobject.NewRegistry()
 
-		s, err := NewNodeReg(newNodeConfig(false), reg)
+		s, err := NewNodeReg(newConfig(false), reg)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -135,7 +135,7 @@ func TestNewNodeReg(t *testing.T) {
 	})
 
 	t.Run("invalid gnet.Config", func(t *testing.T) {
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 		conf.Config.DialTimeout = -1000
 		if s, err := NewNode(conf); err == nil {
 			t.Error("missing error")
@@ -148,7 +148,7 @@ func TestNewNodeReg(t *testing.T) {
 func TestNode_starting(t *testing.T) {
 
 	t.Run("disable listener", func(t *testing.T) {
-		s, err := NewNode(newNodeConfig(false))
+		s, err := NewNode(newConfig(false))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -160,7 +160,7 @@ func TestNode_starting(t *testing.T) {
 	})
 
 	t.Run("enable listener", func(t *testing.T) {
-		s, err := NewNode(newNodeConfig(true))
+		s, err := NewNode(newConfig(true))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -172,7 +172,7 @@ func TestNode_starting(t *testing.T) {
 	})
 
 	t.Run("disable RPC listener", func(t *testing.T) {
-		s, err := NewNode(newNodeConfig(false))
+		s, err := NewNode(newConfig(false))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -184,7 +184,7 @@ func TestNode_starting(t *testing.T) {
 	})
 
 	t.Run("enable RPC listener", func(t *testing.T) {
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 		conf.EnableRPC = true
 
 		s, err := NewNode(conf)
@@ -203,7 +203,7 @@ func TestNode_Close(t *testing.T) {
 	// Close() (err error)
 
 	t.Run("close listener", func(t *testing.T) {
-		s, err := NewNode(newNodeConfig(true))
+		s, err := NewNode(newConfig(true))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -217,7 +217,7 @@ func TestNode_Close(t *testing.T) {
 	})
 
 	t.Run("close RPC listener", func(t *testing.T) {
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 		conf.EnableRPC = true
 
 		s, err := NewNode(conf)
@@ -236,7 +236,7 @@ func TestNode_Close(t *testing.T) {
 	t.Run("twice", func(t *testing.T) {
 		defer clean()
 
-		conf := newNodeConfig(true)
+		conf := newConfig(true)
 		conf.EnableRPC = true
 		conf.InMemoryDB = false // force to use BoltDBs
 
@@ -259,7 +259,7 @@ func TestNode_Close(t *testing.T) {
 func TestNode_Pool(t *testing.T) {
 	// Pool() (pool *gnet.Pool)
 
-	s, err := NewNode(newNodeConfig(false))
+	s, err := NewNode(newConfig(false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,8 +276,8 @@ func (s *Node) lenPending() int {
 	return len(s.pending)
 }
 
-func testNodeSubscribe_local(t *testing.T) {
-	s, err := NewNode(newNodeConfig(false))
+func testNodeSubscribeLocal(t *testing.T) {
+	s, err := NewNode(newConfig(false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,11 +305,11 @@ func testNodeSubscribe_local(t *testing.T) {
 
 }
 
-func testNodeSubscribe_remoteReject(t *testing.T) {
+func testNodeSubscribeRemoteReject(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 
-	aconf := newNodeConfig(false)
-	bconf := newNodeConfig(false)
+	aconf := newConfig(false)
+	bconf := newConfig(false)
 
 	reject := make(chan *gnet.Conn, 1)
 
@@ -350,11 +350,11 @@ func testNodeSubscribe_remoteReject(t *testing.T) {
 
 }
 
-func testNodeSubscribe_remoteAccept(t *testing.T) {
+func testNodeSubscribeRemoteAccept(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 
-	aconf := newNodeConfig(false)
-	bconf := newNodeConfig(false)
+	aconf := newConfig(false)
+	bconf := newConfig(false)
 
 	accept := make(chan *gnet.Conn, 1)
 
@@ -396,11 +396,11 @@ func testNodeSubscribe_remoteAccept(t *testing.T) {
 
 }
 
-func testNodeSubscribe_remoteAcceptTwice(t *testing.T) {
+func testNodeSubscribeRemoteAcceptTwice(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 
-	aconf := newNodeConfig(false)
-	bconf := newNodeConfig(false)
+	aconf := newConfig(false)
+	bconf := newConfig(false)
 
 	accept := make(chan *gnet.Conn, 1)
 
@@ -458,15 +458,15 @@ func testNodeSubscribe_remoteAcceptTwice(t *testing.T) {
 func TestNode_Subscribe(t *testing.T) {
 	// Subscribe(c *gnet.Conn, feed cipher.PubKey)
 
-	t.Run("local", testNodeSubscribe_local)
-	t.Run("remote reject", testNodeSubscribe_remoteReject)
-	t.Run("remote accept", testNodeSubscribe_remoteAccept)
-	t.Run("remote accept twice", testNodeSubscribe_remoteAcceptTwice)
+	t.Run("local", testNodeSubscribeLocal)
+	t.Run("remote reject", testNodeSubscribeRemoteReject)
+	t.Run("remote accept", testNodeSubscribeRemoteAccept)
+	t.Run("remote accept twice", testNodeSubscribeRemoteAcceptTwice)
 
 }
 
-func testNodeUnsubscribe_local(t *testing.T) {
-	s, err := NewNode(newNodeConfig(false))
+func testNodeUnsubscribeLocal(t *testing.T) {
+	s, err := NewNode(newConfig(false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,11 +490,11 @@ func testNodeUnsubscribe_local(t *testing.T) {
 
 }
 
-func testNodeUnsubscribe_remoteSingle(t *testing.T) {
+func testNodeUnsubscribeRemoteSingle(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 
-	aconf := newNodeConfig(false)
-	bconf := newNodeConfig(false)
+	aconf := newConfig(false)
+	bconf := newConfig(false)
 
 	accept := make(chan *gnet.Conn, 1)
 
@@ -564,13 +564,13 @@ func receiveChanTimeout(c <-chan struct{}, tm time.Duration) (ok bool) {
 
 // TODO: DRY
 
-func testNodeUnsubscribe_remoteMany(t *testing.T) {
+func testNodeUnsubscribeRemoteMany(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 
 	// create
 
-	aconf := newNodeConfig(false) // client subscribes
-	sconf := newNodeConfig(true)  // b and c (servers)
+	aconf := newConfig(false) // client subscribes
+	sconf := newConfig(true)  // b and c (servers)
 
 	accept := make(chan struct{}, 1)
 	aconf.OnSubscriptionAccepted = func(_ *gnet.Conn, feed cipher.PubKey) {
@@ -671,10 +671,10 @@ func testNodeUnsubscribe_remoteMany(t *testing.T) {
 
 }
 
-func testNodeUnsubscribe_removeFromPending(t *testing.T) {
+func testNodeUnsubscribeRemoveFromPending(t *testing.T) {
 	pk, _ := cipher.GenerateKeyPair()
 
-	a, err := NewNode(newNodeConfig(false))
+	a, err := NewNode(newConfig(false))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -718,17 +718,17 @@ func testNodeUnsubscribe_removeFromPending(t *testing.T) {
 func TestNode_Unsubscribe(t *testing.T) {
 	// Unsubscribe(c *gnet,.Conn, feed cipher.PubKey)
 
-	t.Run("local", testNodeUnsubscribe_local)
-	t.Run("remote single", testNodeUnsubscribe_remoteSingle)
-	t.Run("remote many", testNodeUnsubscribe_remoteMany)
-	t.Run("remove from pending", testNodeUnsubscribe_removeFromPending)
+	t.Run("local", testNodeUnsubscribeLocal)
+	t.Run("remote single", testNodeUnsubscribeRemoteSingle)
+	t.Run("remote many", testNodeUnsubscribeRemoteMany)
+	t.Run("remove from pending", testNodeUnsubscribeRemoveFromPending)
 }
 
 func TestNewNode_loadingFeeds(t *testing.T) {
 
 	defer clean()
 
-	conf := newNodeConfig(false)
+	conf := newConfig(false)
 	conf.InMemoryDB = false
 
 	s, err := NewNode(conf)
@@ -792,7 +792,7 @@ func TestNode_SubscribeResponse(t *testing.T) {
 	// SubscribeResponse(c *gnet.Conn, feed cipher.PubKey) error
 
 	t.Run("accept", func(t *testing.T) {
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 
 		a, b, ac, _, err := newConnectedNodes(conf, conf)
 		if err != nil {
@@ -814,7 +814,7 @@ func TestNode_SubscribeResponse(t *testing.T) {
 	})
 
 	t.Run("reject", func(t *testing.T) {
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 
 		a, b, ac, _, err := newConnectedNodes(conf, conf)
 		if err != nil {
@@ -836,7 +836,7 @@ func TestNode_SubscribeResponse(t *testing.T) {
 	})
 
 	t.Run("timeout", func(t *testing.T) {
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 		conf.ResponseTimeout = TM
 
 		a, err := NewNode(conf)
@@ -893,8 +893,8 @@ func TestNode_ListOfFeedsResponse(t *testing.T) {
 	// ListOfFeedsResponse(c *gnet.Conn) ([]cipher.PubKey, error)
 
 	t.Run("success", func(t *testing.T) {
-		aconf := newNodeConfig(false)
-		bconf := newNodeConfig(true)
+		aconf := newConfig(false)
+		bconf := newConfig(true)
 		bconf.PublicServer = true
 
 		a, b, ac, _, err := newConnectedNodes(aconf, bconf)
@@ -921,7 +921,7 @@ func TestNode_ListOfFeedsResponse(t *testing.T) {
 	})
 
 	t.Run("non-public", func(t *testing.T) {
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 
 		a, b, ac, _, err := newConnectedNodes(conf, conf)
 		if err != nil {
@@ -941,7 +941,7 @@ func TestNode_ListOfFeedsResponse(t *testing.T) {
 	})
 
 	t.Run("timeout", func(t *testing.T) {
-		conf := newNodeConfig(false)
+		conf := newConfig(false)
 		conf.ResponseTimeout = TM
 
 		a, err := NewNode(conf)
@@ -1003,7 +1003,7 @@ func TestNode_resubscribe(t *testing.T) {
 		t.Skip("short")
 	}
 
-	aconf := newNodeConfig(false)
+	aconf := newConfig(false)
 	aconf.Log.Prefix = "[A CLIENT]"
 	aconf.Config.RedialTimeout = 0 // redial immediately
 	aconf.Config.OnDial = nil      // clear any default redialing filters
@@ -1015,7 +1015,7 @@ func TestNode_resubscribe(t *testing.T) {
 	// we can't use OnSubscriptionAccepted because it never called
 	// if remote peer already subscribed to a feed by this (local)
 	// node; but we can use OnSubscribeRemote of b
-	bconf := newNodeConfig(true)
+	bconf := newConfig(true)
 	bconf.Log.Prefix = "[B SERVER]"
 	subs := make(chan cipher.PubKey, 1)
 	bconf.OnSubscribeRemote = func(_ *gnet.Conn, feed cipher.PubKey) (_ error) {

--- a/node/replicating_test.go
+++ b/node/replicating_test.go
@@ -107,10 +107,10 @@ func Test_replicating(t *testing.T) {
 			return
 		}
 
-		root.Inject("test.User", User{
+		root.Append(root.MustDynamic("test.User", User{
 			Name: "Alice",
 			Age:  19,
-		})
+		}))
 
 		// after this Inject call root object saved and
 		// referes to the registry, now we can safely unlock GC
@@ -291,10 +291,10 @@ func Test_passThrough(t *testing.T) {
 		return
 	}
 
-	root.Inject("test.User", User{
+	root.Append(root.MustDynamic("test.User", User{
 		Name: "Alice",
-		Age:  21,
-	})
+		Age:  19,
+	}))
 
 	//
 	// receive / fill

--- a/node/replicating_test.go
+++ b/node/replicating_test.go
@@ -197,48 +197,33 @@ func Test_passThrough(t *testing.T) {
 	// a
 	//
 
-	a, err := newNodeReg(aconf, reg)
+	a, err := NewNodeReg(aconf, reg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer a.Close()
 
-	if err := a.Start(); err != nil {
-		t.Error(err)
-		return
-	}
-
 	//
 	// b
 	//
 
-	b, err := newNode(newNodeConfig(true)) // listen
+	b, err := NewNode(newNodeConfig(true)) // listen
 	if err != nil {
 		t.Error(err)
 		return
 	}
 	defer b.Close()
 
-	if err := b.Start(); err != nil {
-		t.Error(err)
-		return
-	}
-
 	//
 	// c
 	//
 
-	c, err := newNode(cconf)
+	c, err := NewNode(cconf)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 	defer c.Close()
-
-	if err := c.Start(); err != nil {
-		t.Error(err)
-		return
-	}
 
 	//
 	// dial
@@ -265,9 +250,7 @@ func Test_passThrough(t *testing.T) {
 	c.Subscribe(cc, pk)
 
 	for i := 0; i < 2; i++ {
-		select {
-		case <-accept:
-		case <-time.After(TM):
+		if !receiveChanTimeout(accept, TM) {
 			t.Error("slow")
 			return
 		}

--- a/node/replicating_test.go
+++ b/node/replicating_test.go
@@ -10,21 +10,32 @@ import (
 	"github.com/skycoin/cxo/skyobject"
 )
 
-// from one node to another
-func Test_replicating(t *testing.T) {
+type User struct {
+	Name string
+	Age  uint32
+}
+
+type Group struct {
+	Name   string
+	Leader skyobject.Reference  `skyobject:"schema=test.User"`
+	Users  skyobject.References `skyobject:"schema=test.User"`
+}
+
+func testRegistry() (reg *skyobject.Registry) {
 
 	// tpyes
 
-	type User struct {
-		Name string
-		Age  uint32
-	}
+	reg = skyobject.NewRegistry()
 
-	type Group struct {
-		Name   string
-		Leader skyobject.Reference  `skyobject:"schema=test.User"`
-		Users  skyobject.References `skyobject:"schema=test.User"`
-	}
+	reg.Register("test.User", User{})
+	reg.Register("test.Group", Group{})
+
+	return
+
+}
+
+// from one node to another
+func Test_replicating(t *testing.T) {
 
 	// feed and owner
 
@@ -84,10 +95,7 @@ func Test_replicating(t *testing.T) {
 	// I don't want to reimplement newConenctedNodes, thus
 	// I will use NewRootReg instead of NewRoot
 
-	reg := skyobject.NewRegistry()
-
-	reg.Register("test.User", User{})
-	reg.Register("test.Group", Group{})
+	reg := testRegistry()
 
 	// core registry will be never removed by GC
 	// but this non-core registry can be removed by GC
@@ -139,19 +147,6 @@ func Test_replicating(t *testing.T) {
 // the same as replicating, but 1 -> 2 -> 3
 func Test_passThrough(t *testing.T) {
 
-	// tpyes
-
-	type User struct {
-		Name string
-		Age  uint32
-	}
-
-	type Group struct {
-		Name   string
-		Leader skyobject.Reference  `skyobject:"schema=test.User"`
-		Users  skyobject.References `skyobject:"schema=test.User"`
-	}
-
 	// feed and owner
 
 	pk, sk := cipher.GenerateKeyPair()
@@ -196,10 +191,7 @@ func Test_passThrough(t *testing.T) {
 	// registry
 	//
 
-	reg := skyobject.NewRegistry()
-
-	reg.Register("test.User", User{})
-	reg.Register("test.Group", Group{})
+	reg := testRegistry()
 
 	//
 	// a

--- a/node/replicating_test.go
+++ b/node/replicating_test.go
@@ -43,7 +43,7 @@ func Test_replicating(t *testing.T) {
 
 	// a config
 
-	aconf := newNodeConfig(false)
+	aconf := newConfig(false)
 
 	accept := make(chan struct{})
 
@@ -53,7 +53,7 @@ func Test_replicating(t *testing.T) {
 
 	// b config
 
-	bconf := newNodeConfig(true)
+	bconf := newConfig(true)
 
 	received := make(chan struct{})
 	filled := make(chan struct{})
@@ -153,7 +153,7 @@ func Test_passThrough(t *testing.T) {
 
 	// a config
 
-	aconf := newNodeConfig(false)
+	aconf := newConfig(false)
 	aconf.GCInterval = 0 // disable GC
 
 	accept := make(chan struct{}) // used by a and c
@@ -166,7 +166,7 @@ func Test_passThrough(t *testing.T) {
 
 	// c config
 
-	cconf := newNodeConfig(true)
+	cconf := newConfig(true)
 
 	received := make(chan struct{})
 	filled := make(chan struct{})
@@ -207,7 +207,7 @@ func Test_passThrough(t *testing.T) {
 	// b
 	//
 
-	b, err := NewNode(newNodeConfig(true)) // listen
+	b, err := NewNode(newConfig(true)) // listen
 	if err != nil {
 		t.Error(err)
 		return

--- a/node/rootwalker.go
+++ b/node/rootwalker.go
@@ -469,7 +469,7 @@ func (w *RootWalker) RemoveInRefsField(fieldName string, finder func(i int, ref 
 	return ErrObjNotFound
 }
 
-// RemoveByRef removes a reference in a field of type `skyobject.References`.
+// RemoveInRefsByRef removes a reference in a field of type `skyobject.References`.
 // It uses the Finder implementation to find the reference to remove.
 func (w *RootWalker) RemoveInRefsByRef(fieldName string, fRef skyobject.Reference) error {
 	// Obtain top-most object from internal stack.

--- a/node/rootwalker_test.go
+++ b/node/rootwalker_test.go
@@ -95,9 +95,13 @@ func fillContainer1(c *Container, pk cipher.PubKey,
 		Thread{"Expressions", persons[2], posts2},
 		Thread{"Testing", persons[3], posts3},
 	)
-	r.InjectMany("Board",
-		Board{"Test", persons[3], dynPost, threads[2:]},
-		Board{"Talk", persons[1], dynPerson, threads[:2]},
+	r.Append(
+		r.MustDynamic("Board",
+			Board{"Test", persons[3], dynPost, threads[2:]},
+		),
+		r.MustDynamic("Board",
+			Board{"Talk", persons[1], dynPerson, threads[:2]},
+		),
 	)
 
 	return

--- a/node/rootwalker_test.go
+++ b/node/rootwalker_test.go
@@ -49,13 +49,8 @@ func newRootwalkerClient(t *testing.T, pk cipher.PubKey) (c *Node) {
 	reg.Register("Board", Board{})
 
 	var err error
-	if c, err = newNodeReg(newNodeConfig(false), reg); err != nil {
+	if c, err = NewNodeReg(newNodeConfig(false), reg); err != nil {
 		t.Fatal(err) // fatality
-	}
-
-	if err = c.Start(); err != nil {
-		c.Close()
-		t.Fatal(err)
 	}
 
 	c.Subscribe(nil, pk)

--- a/node/rootwalker_test.go
+++ b/node/rootwalker_test.go
@@ -49,7 +49,7 @@ func newRootwalkerClient(t *testing.T, pk cipher.PubKey) (c *Node) {
 	reg.Register("Board", Board{})
 
 	var err error
-	if c, err = NewNodeReg(newNodeConfig(false), reg); err != nil {
+	if c, err = NewNodeReg(newConfig(false), reg); err != nil {
 		t.Fatal(err) // fatality
 	}
 

--- a/node/rpc.go
+++ b/node/rpc.go
@@ -52,7 +52,7 @@ func (r *RPC) Address() (address string) {
 	return
 }
 
-// Clsoe RPC server
+// Close RPC server
 func (r *RPC) Close() (err error) {
 	if r.l != nil {
 		err = r.l.Close()
@@ -81,11 +81,13 @@ func (r *RPC) Close() (err error) {
 // - Tree
 // - Terminate
 
+// Want on a feed
 func (r *RPC) Want(feed cipher.PubKey, list *[]cipher.SHA256) (_ error) {
 	*list = r.ns.Want(feed)
 	return
 }
 
+// Got of a feed
 func (r *RPC) Got(feed cipher.PubKey, list *[]cipher.SHA256) (_ error) {
 	*list = r.ns.Got(feed)
 	return
@@ -98,6 +100,7 @@ type ConnFeed struct {
 	Feed    cipher.PubKey
 }
 
+// Subscribe to a connection+feed
 func (r *RPC) Subscribe(cf ConnFeed, _ *struct{}) (err error) {
 	if cf.Address == "" {
 		r.ns.Subscribe(nil, cf.Feed)
@@ -110,6 +113,7 @@ func (r *RPC) Subscribe(cf ConnFeed, _ *struct{}) (err error) {
 	return errors.New("no such connection: " + cf.Address)
 }
 
+// Unsubscribe from a connection+feed
 func (r *RPC) Unsubscribe(cf ConnFeed, _ *struct{}) (_ error) {
 	if cf.Address == "" {
 		r.ns.Unsubscribe(nil, cf.Feed)
@@ -122,16 +126,19 @@ func (r *RPC) Unsubscribe(cf ConnFeed, _ *struct{}) (_ error) {
 	return errors.New("no such connection: " + cf.Address)
 }
 
+// Feeds of a node
 func (r *RPC) Feeds(_ struct{}, list *[]cipher.PubKey) (_ error) {
 	*list = r.ns.Feeds()
 	return
 }
 
+// Stat of database
 func (r *RPC) Stat(_ struct{}, stat *data.Stat) (_ error) {
 	*stat = r.ns.db.Stat()
 	return
 }
 
+// Connections of a node
 func (r *RPC) Connections(_ struct{}, list *[]string) (_ error) {
 	cs := r.ns.pool.Connections()
 	if len(cs) == 0 {
@@ -145,6 +152,7 @@ func (r *RPC) Connections(_ struct{}, list *[]string) (_ error) {
 	return
 }
 
+// IncomingConnections of a node
 func (r *RPC) IncomingConnections(_ struct{}, list *[]string) (_ error) {
 	var l []string
 	for _, c := range r.ns.pool.Connections() {
@@ -156,6 +164,7 @@ func (r *RPC) IncomingConnections(_ struct{}, list *[]string) (_ error) {
 	return
 }
 
+// OutgoingConnections of a node
 func (r *RPC) OutgoingConnections(_ struct{}, list *[]string) (_ error) {
 	var l []string
 	for _, c := range r.ns.pool.Connections() {
@@ -167,11 +176,13 @@ func (r *RPC) OutgoingConnections(_ struct{}, list *[]string) (_ error) {
 	return
 }
 
+// Connect to a remote peer
 func (r *RPC) Connect(address string, _ *struct{}) (err error) {
 	_, err = r.ns.pool.Dial(address)
 	return
 }
 
+// Disconnect from a remote peer
 func (r *RPC) Disconnect(address string, _ *struct{}) (err error) {
 	if c := r.ns.pool.Connection(address); c != nil {
 		err = c.Close()
@@ -179,12 +190,13 @@ func (r *RPC) Disconnect(address string, _ *struct{}) (err error) {
 	return errors.New("no such connection: " + address)
 }
 
-// LsiteningAddress of Node
+// ListeningAddress of Node
 func (r *RPC) ListeningAddress(_ struct{}, address *string) (_ error) {
 	*address = r.ns.pool.Address()
 	return
 }
 
+// A RootInfo used by RPC
 type RootInfo struct {
 	Time   time.Time
 	Seq    uint64

--- a/skyobject/CHANGELOG.md
+++ b/skyobject/CHANGELOG.md
@@ -15,18 +15,20 @@ changes
 
 #### 13:20 16 June 2017 UTC
 
-*There are breaking changes*
+- [x] `(*Root).Inject, InjectMany -> Append`
 
-- [x] rename `(*Root).Inject, InjectMany -> Append`
-
-Also:
-
++ `(*Root).Inject` and `injectMany` has been marked as __deprecated__
++ introduced `(*Root).Append()drs ...Dynamic)` method
 + introduced `(*Root).Slice(i, j int) (dr []Dynamic, err error)` method
 + introduced `(*Root).Index(i int) (dr Dynamic, err error)` method
++ introduced `(*Root).Len() int` method
 
 So, the changes are for semantics. A `Root` contains slice of references and
-methods `Append`, `Index` and `Slice` are intuitive. Methods `Inject` and
-`InjectMany` are not depricated, but removed
+methods `Append`, `Index` and `Slice` are intuitive
+
+The `Slice` method returns unsafe slice. But `Refs` method returns
+safe copy of references of a `Root`.
+
 
 ####  1:00 16 June 2017 UTC
 

--- a/skyobject/CHANGELOG.md
+++ b/skyobject/CHANGELOG.md
@@ -13,7 +13,7 @@ changes
 
 ### Done
 
-#### 14:00 17 June 2017 UTC
+#### 16:15 17 June 2017 UTC
 
 - [x] `(*Root).Inject, InjectMany -> Append`
 

--- a/skyobject/CHANGELOG.md
+++ b/skyobject/CHANGELOG.md
@@ -13,7 +13,7 @@ changes
 
 ### Done
 
-#### 13:20 16 June 2017 UTC
+#### 14:00 17 June 2017 UTC
 
 - [x] `(*Root).Inject, InjectMany -> Append`
 

--- a/skyobject/CHANGELOG.md
+++ b/skyobject/CHANGELOG.md
@@ -8,9 +8,25 @@ changes
 - [ ] fix user-provided-schema-name issue #98
 - [ ] add tests for `(*Container).RangeFeed`
 - [ ] add tests for `(*Container).RootByHash`
-- [ ] rename `(*Root).Inject, InjectMany -> Append`
+- [ ] add test for `(*Root).Index`
+- [ ] add test for `(*Root).Slice`
 
 ### Done
+
+#### 13:20 16 June 2017 UTC
+
+*There are breaking changes*
+
+- [x] rename `(*Root).Inject, InjectMany -> Append`
+
+Also:
+
++ introduced `(*Root).Slice(i, j int) (dr []Dynamic, err error)` method
++ introduced `(*Root).Index(i int) (dr Dynamic, err error)` method
+
+So, the changes are for semantics. A `Root` contains slice of references and
+methods `Append`, `Index` and `Slice` are intuitive. Methods `Inject` and
+`InjectMany` are not depricated, but removed
 
 ####  1:00 16 June 2017 UTC
 

--- a/skyobject/container.go
+++ b/skyobject/container.go
@@ -11,6 +11,8 @@ import (
 )
 
 var (
+	// ErrNoCoreRegistry occurs while you are trying to call NewRoot
+	// of Container that created without Registry
 	ErrNoCoreRegistry = errors.New(
 		"missing registry, Container created without registry")
 	// ErrAlreadyHaveThisRoot occurs when Container already have
@@ -151,10 +153,9 @@ func (c *Container) WantRegistry(rr RegistryReference) (want bool) {
 				if _, ok := c.registries[rr]; !ok {
 					want, stop = true, true // want
 					return
-				} else {
-					have, stop = true, true // already have
-					return
 				}
+				have, stop = true, true // already have
+				return
 			}
 			return // continue
 		})

--- a/skyobject/container.go
+++ b/skyobject/container.go
@@ -467,7 +467,8 @@ func (c *Container) DelFeed(pk cipher.PubKey) {
 // but not returns the error
 type RangeFeedFunc func(r *Root) (err error)
 
-// RangeFeed itterates root obejcts of given feed from old to new
+// RangeFeed itterates root obejcts of given feed from old to new.
+// Given RangeFeedFunc must be read-only
 func (c *Container) RangeFeed(pk cipher.PubKey, fn RangeFeedFunc) (err error) {
 	c.db.RangeFeed(pk, func(rp *data.RootPack) (stop bool) {
 		var err error

--- a/skyobject/container.go
+++ b/skyobject/container.go
@@ -471,7 +471,6 @@ type RangeFeedFunc func(r *Root) (err error)
 // Given RangeFeedFunc must be read-only
 func (c *Container) RangeFeed(pk cipher.PubKey, fn RangeFeedFunc) (err error) {
 	c.db.RangeFeed(pk, func(rp *data.RootPack) (stop bool) {
-		var err error
 		var r *Root
 		if r, err = c.unpackRoot(rp); err != nil {
 			panic(err) // critical

--- a/skyobject/container_test.go
+++ b/skyobject/container_test.go
@@ -105,7 +105,11 @@ func TestContainer_WantRegistry(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, rp, err := r.Inject("cxo.User", User{"Alice", 20, nil})
+		alice, err := r.Dynamic("cxo.User", User{"Alice", 20, nil})
+		if err != nil {
+			t.Fatal(err)
+		}
+		rp, err := r.Append(alice)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -528,6 +532,8 @@ func TestContainer_LastFullRoot(t *testing.T) {
 		}
 	})
 	t.Run("found", func(t *testing.T) {
+		defer shouldNotPanic(t) // for insurance
+
 		c := getCont()
 		pk, sk := cipher.GenerateKeyPair()
 		r, err := c.NewRoot(pk, sk)
@@ -535,9 +541,9 @@ func TestContainer_LastFullRoot(t *testing.T) {
 			t.Error(err)
 			return
 		}
-		r.Inject("cxo.User", User{"Alice", 15, nil})
-		r.Inject("cxo.User", User{"Eva", 16, nil})
-		r.Inject("cxo.User", User{"Ammy", 17, nil})
+		r.Append(r.MustDynamic("cxo.User", User{"Alice", 15, nil}))
+		r.Append(r.MustDynamic("cxo.User", User{"Eva", 16, nil}))
+		r.Append(r.MustDynamic("cxo.User", User{"Ammy", 17, nil}))
 		full := c.LastFullRoot(pk)
 		if full == nil {
 			t.Error("misisng last full root")
@@ -615,15 +621,22 @@ func TestContainer_WantFeed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	alice, _, err := r.Inject("cxo.User", User{"Alice", 20, nil})
-	if err != nil {
+	//
+	var aliceUser, evaUser, ammyUser User = User{"Alice", 20, nil},
+		User{"Eva", 21, nil}, User{"Ammy", 16, nil}
+	//
+	var alice, eva, ammy Dynamic
+	if alice, err = r.Dynamic("cxo.User", aliceUser); err != nil {
 		t.Fatal(err)
 	}
-	eva, _, err := r.Inject("cxo.User", User{"Eva", 21, nil})
-	if err != nil {
+	if eva, err = r.Dynamic("cxo.User", evaUser); err != nil {
 		t.Fatal(err)
 	}
-	ammy, rp, err := r.Inject("cxo.User", User{"Ammy", 16, nil})
+	if ammy, err = r.Dynamic("cxo.User", ammyUser); err != nil {
+		t.Fatal(err)
+	}
+	//
+	rp, err := r.Append(alice, eva, ammy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -724,18 +737,28 @@ func TestContainer_GotFeed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	alice, _, err := r.Inject("cxo.User", User{"Alice", 20, nil})
+
+	//
+	var aliceUser, evaUser, ammyUser User = User{"Alice", 20, nil},
+		User{"Eva", 21, nil}, User{"Ammy", 16, nil}
+	//
+	var alice, eva, ammy Dynamic
+	if alice, err = r.Dynamic("cxo.User", aliceUser); err != nil {
+		t.Fatal(err)
+	}
+	if eva, err = r.Dynamic("cxo.User", evaUser); err != nil {
+		t.Fatal(err)
+	}
+	if ammy, err = r.Dynamic("cxo.User", ammyUser); err != nil {
+		t.Fatal(err)
+	}
+	//
+	rp, err := r.Append(alice, eva, ammy)
 	if err != nil {
 		t.Fatal(err)
 	}
-	eva, _, err := r.Inject("cxo.User", User{"Eva", 21, nil})
-	if err != nil {
-		t.Fatal(err)
-	}
-	ammy, rp, err := r.Inject("cxo.User", User{"Ammy", 16, nil})
-	if err != nil {
-		t.Fatal(err)
-	}
+	//
+
 	// receiver
 	receiver := NewContainer(data.NewMemoryDB(), nil)
 	if r, err = receiver.AddRootPack(&rp); err != nil {
@@ -889,17 +912,21 @@ func TestContainer_GC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = r.Inject("cxo.User", User{"Alice", 20, nil})
+	alice, err := r.Dynamic("cxo.User", User{"Alice", 20, nil})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = r.Replace([]Dynamic{
+	_, err = r.Append(alice)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = r.Replace([]Dynamic{
 		r.MustDynamic("cxo.User", User{"Eva", 21, nil}),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = r.Replace([]Dynamic{
+	_, err = r.Replace([]Dynamic{
 		r.MustDynamic("cxo.User", User{"Ammy", 16, nil}),
 	})
 	if err != nil {

--- a/skyobject/container_test.go
+++ b/skyobject/container_test.go
@@ -662,9 +662,9 @@ func TestContainer_WantFeed(t *testing.T) {
 		t.Fatal("wrong wants")
 	}
 	set := map[Reference]struct{}{
-		alice.Object: struct{}{},
-		eva.Object:   struct{}{},
-		ammy.Object:  struct{}{},
+		alice.Object: {},
+		eva.Object:   {},
+		ammy.Object:  {},
 	}
 	for _, w := range want {
 		if _, ok := set[w]; !ok {
@@ -794,7 +794,7 @@ func TestContainer_GotFeed(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatal("wrong gots", got)
 	}
-	set := map[Reference]struct{}{alice.Object: struct{}{}}
+	set := map[Reference]struct{}{alice.Object: {}}
 	for _, w := range got {
 		if _, ok := set[w]; !ok {
 			t.Fatal("wrong ref")

--- a/skyobject/example_test.go
+++ b/skyobject/example_test.go
@@ -47,8 +47,7 @@ func Example() {
 
 	// callings of
 	//  - Touch
-	//  - Inject
-	//  - InjectMany
+	//  - Append
 	//  - Replace
 	// (1) increment seq number of the root
 	// (2) set its timestamp to now
@@ -58,7 +57,7 @@ func Example() {
 	// thus every of the callings create new version
 	// of the root
 
-	root.Inject("test.Group", Group{
+	root.Append(root.MustDynamic("test.Group", Group{
 		Name: "group #1",
 		Leader: root.Save(User{
 			Name:   "Bob Marley",
@@ -74,7 +73,7 @@ func Example() {
 			Name:   "kostyarin",
 			GitHub: "logrusorgru",
 		}),
-	})
+	}))
 
 	// TODO
 

--- a/skyobject/inspect.go
+++ b/skyobject/inspect.go
@@ -46,19 +46,7 @@ func valueItem(val *Value) (item gotree.GTStructure) {
 	var err error
 	switch val.Kind() {
 	case reflect.Struct:
-		item.Name = "struct " + val.Schema().Name()
-
-		err = val.RangeFields(func(name string,
-			val *Value) (_ error) {
-
-			var field gotree.GTStructure
-			field.Name = "(field) " + name
-			field.Items = []gotree.GTStructure{
-				valueItem(val),
-			}
-			item.Items = append(item.Items, field)
-			return
-		})
+		item, err = valueItemStruct(val)
 	case reflect.Ptr:
 
 		if val.Schema().ReferenceType() == ReferenceTypeSingle {
@@ -104,50 +92,9 @@ func valueItem(val *Value) (item gotree.GTStructure) {
 			item.Name = fmt.Sprint(f)
 		}
 	case reflect.Array:
-		item.Name = val.Schema().Name()
-		if item.Name == "" {
-			// unnamed type
-			var ln int
-			if ln, err = val.Len(); err != nil {
-				break
-			}
-			if val.Schema().Elem() == nil {
-				err = ErrInvalidSchema
-				break
-			}
-			item.Name = fmt.Sprintf("[%d]", ln) + val.Schema().Elem().String()
-		}
-		err = val.RangeIndex(func(_ int, val *Value) (_ error) {
-			item.Items = append(item.Items, valueItem(val))
-			return
-		})
+		item, err = valueItemArray(val)
 	case reflect.Slice:
-		// special case for []byte
-		sch := val.Schema()
-		if sch.Kind() == reflect.Slice && sch.Elem().Kind() == reflect.Uint8 {
-			var bt []byte
-			if bt, err = val.Bytes(); err != nil {
-				break
-			}
-			item.Name = "[]byte"
-			item.Items = []gotree.GTStructure{
-				{Name: hex.EncodeToString(bt)},
-			}
-			return
-		}
-		// including References
-		if item.Name = sch.Name(); item.Name == "" {
-			// unnamed type
-			if sch.Elem() == nil {
-				err = ErrInvalidSchema
-				break
-			}
-			item.Name = "[]" + sch.Elem().String()
-		}
-		err = val.RangeIndex(func(_ int, val *Value) (_ error) {
-			item.Items = append(item.Items, valueItem(val))
-			return
-		})
+		item, err = valueItemSlice(val)
 	case reflect.String:
 		var s string
 		if s, err = val.String(); err == nil {
@@ -159,5 +106,72 @@ func valueItem(val *Value) (item gotree.GTStructure) {
 		item.Name = "error: " + err.Error()
 		item.Items = nil // clear
 	}
+	return
+}
+
+func valueItemStruct(val *Value) (item gotree.GTStructure, err error) {
+	item.Name = "struct " + val.Schema().Name()
+
+	err = val.RangeFields(func(name string, val *Value) (_ error) {
+
+		var field gotree.GTStructure
+		field.Name = "(field) " + name
+		field.Items = []gotree.GTStructure{
+			valueItem(val),
+		}
+		item.Items = append(item.Items, field)
+		return
+	})
+	return
+}
+
+func valueItemSlice(val *Value) (item gotree.GTStructure, err error) {
+	// special case for []byte
+	sch := val.Schema()
+	if sch.Kind() == reflect.Slice && sch.Elem().Kind() == reflect.Uint8 {
+		var bt []byte
+		if bt, err = val.Bytes(); err != nil {
+			return
+		}
+		item.Name = "[]byte"
+		item.Items = []gotree.GTStructure{
+			{Name: hex.EncodeToString(bt)},
+		}
+		return
+	}
+	// including References
+	if item.Name = sch.Name(); item.Name == "" {
+		// unnamed type
+		if sch.Elem() == nil {
+			err = ErrInvalidSchema
+			return
+		}
+		item.Name = "[]" + sch.Elem().String()
+	}
+	err = val.RangeIndex(func(_ int, val *Value) (_ error) {
+		item.Items = append(item.Items, valueItem(val))
+		return
+	})
+	return
+}
+
+func valueItemArray(val *Value) (item gotree.GTStructure, err error) {
+	item.Name = val.Schema().Name()
+	if item.Name == "" {
+		// unnamed type
+		var ln int
+		if ln, err = val.Len(); err != nil {
+			return
+		}
+		if val.Schema().Elem() == nil {
+			err = ErrInvalidSchema
+			return
+		}
+		item.Name = fmt.Sprintf("[%d]", ln) + val.Schema().Elem().String()
+	}
+	err = val.RangeIndex(func(_ int, val *Value) (_ error) {
+		item.Items = append(item.Items, valueItem(val))
+		return
+	})
 	return
 }

--- a/skyobject/inspect.go
+++ b/skyobject/inspect.go
@@ -27,7 +27,7 @@ func rootItems(root *Root) (items []gotree.GTStructure) {
 	vals, err := root.Values()
 	if err != nil {
 		items = []gotree.GTStructure{
-			gotree.GTStructure{Name: "error: " + err.Error()},
+			{Name: "error: " + err.Error()},
 		}
 		return
 	}
@@ -81,7 +81,7 @@ func valueItem(val *Value) (item gotree.GTStructure) {
 			}
 		} else {
 			item.Items = []gotree.GTStructure{
-				gotree.GTStructure{
+				{
 					Name: "error: " + err.Error(),
 				},
 			}
@@ -131,7 +131,7 @@ func valueItem(val *Value) (item gotree.GTStructure) {
 			}
 			item.Name = "[]byte"
 			item.Items = []gotree.GTStructure{
-				gotree.GTStructure{Name: hex.EncodeToString(bt)},
+				{Name: hex.EncodeToString(bt)},
 			}
 			return
 		}

--- a/skyobject/references.go
+++ b/skyobject/references.go
@@ -89,7 +89,7 @@ func (r References) String() (s string) {
 // Dynamic
 //
 
-// A dynamic represents dynamic reference that contains
+// A Dynamic represents dynamic reference that contains
 // reference to schema and reference to object
 type Dynamic struct {
 	Object Reference

--- a/skyobject/registry.go
+++ b/skyobject/registry.go
@@ -290,7 +290,6 @@ func (r *Registry) getSchema(typ reflect.Type) Schema {
 	default:
 		panic("invlaid type: " + typ.String())
 	}
-	return nil // never happens
 }
 
 func (r *Registry) getField(sf reflect.StructField) Field {
@@ -359,7 +358,6 @@ func tagReference(tag reflect.StructTag) string {
 		return ss[1]
 	}
 	panic("invalid skyobject tag: " + skytag)
-	return ""
 }
 
 func typeOf(i interface{}) reflect.Type {

--- a/skyobject/registry.go
+++ b/skyobject/registry.go
@@ -11,8 +11,11 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
+// TAG is name of struct tag the skyobject package use to determine
+// schema of a struct field if the field is reference
 const TAG = "skyobject"
 
+// ErrInvalidEncodedSchema occurs during decoding an invalid registry
 var ErrInvalidEncodedSchema = errors.New("invalid encoded schema")
 
 // A Registry represents registry of schemas.
@@ -41,6 +44,7 @@ type Registry struct {
 	srf  map[SchemaReference]Schema // by reference (for Dynamic references)
 }
 
+// NewRegistry creates fresh empty registry
 func NewRegistry() (r *Registry) {
 	r = new(Registry)
 	r.reg = make(map[string]Schema)
@@ -53,7 +57,7 @@ func NewRegistry() (r *Registry) {
 // Registry already Done
 func DecodeRegistry(b []byte) (r *Registry, err error) {
 	var (
-		res registryEntities = registryEntities{}
+		res = registryEntities{}
 		s   Schema
 	)
 	if err = encoder.DeserializeRaw(b, &res); err != nil {
@@ -69,6 +73,7 @@ func DecodeRegistry(b []byte) (r *Registry, err error) {
 	return
 }
 
+// Register a struct type using provided name
 func (r *Registry) Register(name string, i interface{}) {
 	if r.done {
 		panic("registration was closed")
@@ -79,7 +84,7 @@ func (r *Registry) Register(name string, i interface{}) {
 	if strings.ContainsAny(name, "=,") {
 		panic("invalid symbols in name (comma or equal-sign")
 	}
-	var typ reflect.Type = typeOf(i)
+	typ := typeOf(i)
 	switch typ {
 	case singleRef, sliceRef, dynamicRef:
 		panic("can't register reference type")
@@ -101,6 +106,7 @@ func (r *Registry) Register(name string, i interface{}) {
 	}
 }
 
+// Done closes registration
 func (r *Registry) Done() {
 	if r.done == true {
 		return // already done
@@ -128,6 +134,7 @@ func (r *Registry) SchemaByName(name string) (Schema, error) {
 	return r.schemaByName(name)
 }
 
+// SchemaByReference returns Schema by SchemaReference that is obvious
 func (r *Registry) SchemaByReference(sr SchemaReference) (s Schema, err error) {
 	r.mustBeDone()
 	var ok bool
@@ -137,6 +144,8 @@ func (r *Registry) SchemaByReference(sr SchemaReference) (s Schema, err error) {
 	return
 }
 
+// SchemaReferenceByName returns SchemaReference by registered name of a struct
+// type
 func (r *Registry) SchemaReferenceByName(name string) (sr SchemaReference,
 	err error) {
 

--- a/skyobject/registry_test.go
+++ b/skyobject/registry_test.go
@@ -221,3 +221,28 @@ func TestRegistry_slice(t *testing.T) {
 		}
 	})
 }
+
+func TestRegistry_userProvidedName(t *testing.T) {
+	t.Skip("not implemented yet")
+
+	type Info struct {
+		About string
+	}
+	type Brief struct {
+		Note string
+	}
+	type Any struct {
+		Info
+		Brief Brief
+	}
+	reg := NewRegistry()
+	reg.Register("test.Info", Info{})
+	reg.Register("test.Brief", Brief{})
+	reg.Register("test.Any", Any{})
+
+	defer shouldNotPanic(t)
+
+	reg.Done()
+
+	// TODO
+}

--- a/skyobject/root.go
+++ b/skyobject/root.go
@@ -301,6 +301,54 @@ func (r *Root) MustDynamic(schemaName string, i interface{}) (dr Dynamic) {
 	return
 }
 
+//
+// Inject and InjectMany are depricated
+//
+
+// Inject an object to the Root updating the seq,
+// timestamp and signature of the Root
+//
+// Depricated: use Append instead
+func (r *Root) Inject(schemaName string, i interface{}) (inj Dynamic,
+	rp data.RootPack, err error) {
+
+	if inj, err = r.Dynamic(schemaName, i); err != nil {
+		return
+	}
+	r.Lock()
+	defer r.Unlock()
+	r.refs = append(r.refs, inj)
+	rp, err = r.touch()
+	return
+}
+
+// InjectMany objects to the Root updating the seq,
+// timestamp and signature of the Root
+//
+// Depricated: use Append instead
+func (r *Root) InjectMany(schemaName string, i ...interface{}) (injs []Dynamic,
+	rp data.RootPack, err error) {
+
+	injs = make([]Dynamic, 0, len(i))
+	var inj Dynamic
+	for _, e := range i {
+		if inj, err = r.Dynamic(schemaName, e); err != nil {
+			injs = nil
+			return
+		}
+		injs = append(injs, inj)
+	}
+	r.Lock()
+	defer r.Unlock()
+	r.refs = append(r.refs, injs...)
+	rp, err = r.touch()
+	return
+}
+
+//
+// Append, Len, Slice and Index was introduced
+//
+
 // Append objects to the Root updating the seq,
 // timestamp and signature of the Root
 func (r *Root) Append(drs ...Dynamic) (rp data.RootPack, err error) {

--- a/skyobject/root.go
+++ b/skyobject/root.go
@@ -302,13 +302,13 @@ func (r *Root) MustDynamic(schemaName string, i interface{}) (dr Dynamic) {
 }
 
 //
-// Inject and InjectMany are depricated
+// Inject and InjectMany are Deprecated
 //
 
 // Inject an object to the Root updating the seq,
 // timestamp and signature of the Root
 //
-// Depricated: use Append instead
+// Deprecated: use Append instead
 func (r *Root) Inject(schemaName string, i interface{}) (inj Dynamic,
 	rp data.RootPack, err error) {
 
@@ -325,7 +325,7 @@ func (r *Root) Inject(schemaName string, i interface{}) (inj Dynamic,
 // InjectMany objects to the Root updating the seq,
 // timestamp and signature of the Root
 //
-// Depricated: use Append instead
+// Deprecated: use Append instead
 func (r *Root) InjectMany(schemaName string, i ...interface{}) (injs []Dynamic,
 	rp data.RootPack, err error) {
 

--- a/skyobject/root.go
+++ b/skyobject/root.go
@@ -193,7 +193,7 @@ func (r *Root) IsFull() bool {
 	if !r.attached { // fresh (detached root can't be full)
 		return false
 	}
-	var want bool = false
+	want := false
 	err := r.wantFunc(func(Reference) error {
 		want = true
 		return ErrStopRange
@@ -502,7 +502,7 @@ func (r *Root) Values() (vals []*Value, err error) {
 	return
 }
 
-// SchemaByReference returns Schema by name or
+// SchemaByName returns Schema by name or
 // (1) missing registry error, or (2) missing schema error
 func (r *Root) SchemaByName(name string) (s Schema, err error) {
 	var reg *Registry
@@ -774,13 +774,12 @@ func refsValue(v *Value, rf RefsFunc) (err error) {
 			if skip, err = rf(ref); err != nil || skip {
 				return
 			}
-			if data, ok := v.root.Get(ref); !ok {
-				return // nil
-			} else {
+			if data, ok := v.root.Get(ref); ok {
 				var val *Value
 				val = &Value{data, v.Schema().Elem(), v.root}
 				return refsValue(val, rf)
 			}
+			return // nil
 		case ReferenceTypeDynamic:
 			var dr Dynamic
 			if dr, err = v.Dynamic(); err != nil {

--- a/skyobject/root_test.go
+++ b/skyobject/root_test.go
@@ -390,9 +390,9 @@ func TestRoot_WantFunc(t *testing.T) {
 		t.Fatal("wrong wants")
 	}
 	set := map[Reference]struct{}{
-		alice.Object: struct{}{},
-		eva.Object:   struct{}{},
-		ammy.Object:  struct{}{},
+		alice.Object: {},
+		eva.Object:   {},
+		ammy.Object:  {},
 	}
 	for _, w := range want {
 		if _, ok := set[w]; !ok {
@@ -537,7 +537,7 @@ func TestRoot_GotFunc(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatal("wrong gots", got)
 	}
-	set := map[Reference]struct{}{alice.Object: struct{}{}}
+	set := map[Reference]struct{}{alice.Object: {}}
 	for _, w := range got {
 		if _, ok := set[w]; !ok {
 			t.Fatal("wrong ref")

--- a/skyobject/root_test.go
+++ b/skyobject/root_test.go
@@ -174,8 +174,9 @@ func TestRoot_IsFull(t *testing.T) {
 	if r.IsFull() {
 		t.Error("detached root is full")
 	}
-	_, _, err = r.Inject("cxo.User", User{"Alice", 20, nil})
-	if err != nil {
+	if alice, err := r.Dynamic("cxo.User", User{"Alice", 20, nil}); err != nil {
+		t.Fatal(err)
+	} else if _, err = r.Append(alice); err != nil {
 		t.Fatal(err)
 	}
 	if !r.IsFull() {
@@ -207,8 +208,9 @@ func TestRoot_Encode(t *testing.T) {
 	if _, err := c.unpackRoot(&rp); err != nil {
 		t.Fatal(err)
 	}
-	_, rp, err = r.Inject("cxo.User", User{"Alice", 20, nil})
-	if err != nil {
+	if alice, err := r.Dynamic("cxo.User", User{"Alice", 20, nil}); err != nil {
+		t.Fatal(err)
+	} else if rp, err = r.Append(alice); err != nil {
 		t.Fatal(err)
 	}
 	t.Log(rp)
@@ -338,18 +340,28 @@ func TestRoot_WantFunc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	alice, _, err := r.Inject("cxo.User", User{"Alice", 20, nil})
+
+	//
+	var aliceUser, evaUser, ammyUser User = User{"Alice", 20, nil},
+		User{"Eva", 21, nil}, User{"Ammy", 16, nil}
+	//
+	var alice, eva, ammy Dynamic
+	if alice, err = r.Dynamic("cxo.User", aliceUser); err != nil {
+		t.Fatal(err)
+	}
+	if eva, err = r.Dynamic("cxo.User", evaUser); err != nil {
+		t.Fatal(err)
+	}
+	if ammy, err = r.Dynamic("cxo.User", ammyUser); err != nil {
+		t.Fatal(err)
+	}
+	//
+	rp, err := r.Append(alice, eva, ammy)
 	if err != nil {
 		t.Fatal(err)
 	}
-	eva, _, err := r.Inject("cxo.User", User{"Eva", 21, nil})
-	if err != nil {
-		t.Fatal(err)
-	}
-	ammy, rp, err := r.Inject("cxo.User", User{"Ammy", 16, nil})
-	if err != nil {
-		t.Fatal(err)
-	}
+	//
+
 	// receiver
 	receiver := NewContainer(data.NewMemoryDB(), nil)
 	if r, err = receiver.AddRootPack(&rp); err != nil {
@@ -462,18 +474,26 @@ func TestRoot_GotFunc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	alice, _, err := r.Inject("cxo.User", User{"Alice", 20, nil})
+
+	var aliceUser, evaUser, ammyUser User = User{"Alice", 20, nil},
+		User{"Eva", 21, nil}, User{"Ammy", 16, nil}
+	//
+	var alice, eva, ammy Dynamic
+	if alice, err = r.Dynamic("cxo.User", aliceUser); err != nil {
+		t.Fatal(err)
+	}
+	if eva, err = r.Dynamic("cxo.User", evaUser); err != nil {
+		t.Fatal(err)
+	}
+	if ammy, err = r.Dynamic("cxo.User", ammyUser); err != nil {
+		t.Fatal(err)
+	}
+	//
+	rp, err := r.Append(alice, eva, ammy)
 	if err != nil {
 		t.Fatal(err)
 	}
-	eva, _, err := r.Inject("cxo.User", User{"Eva", 21, nil})
-	if err != nil {
-		t.Fatal(err)
-	}
-	ammy, rp, err := r.Inject("cxo.User", User{"Ammy", 16, nil})
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	// receiver
 	receiver := NewContainer(data.NewMemoryDB(), nil)
 	if r, err = receiver.AddRootPack(&rp); err != nil {

--- a/skyobject/schema.go
+++ b/skyobject/schema.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	// ErrInvalidType occurs when you tries to register any unacceptable type
 	ErrInvalidType = errors.New("invalid type")
 )
 
@@ -19,8 +20,10 @@ var (
 	dynamicRef = typeOf(Dynamic{})
 )
 
+// A ReferenceType represents type of a reference
 type ReferenceType int
 
+// possible reference
 const (
 	ReferenceTypeNone    ReferenceType = iota
 	ReferenceTypeSingle                // Reference (cipher.SHA256)
@@ -28,6 +31,7 @@ const (
 	ReferenceTypeDynamic               // Dynamic (struct{Object, Schema Ref.})
 )
 
+// A Schema represents schema of a CX object
 type Schema interface {
 	// Reference of the Schema. The reference is valid after call of Done of
 	// Registry by which the Schema created
@@ -301,6 +305,7 @@ func (s *structSchema) Encode() (b []byte) {
 
 // field
 
+// A Field represetns struct field
 type Field interface {
 	Schema() Schema     // Schema of the Field
 	Kind() reflect.Kind // kind of the Field (short hand)

--- a/skyobject/value.go
+++ b/skyobject/value.go
@@ -426,15 +426,18 @@ func SchemaSize(s Schema, p []byte) (n int, err error) {
 }
 
 func schemaSliceSize(s Schema, p []byte) (n int, err error) {
+	if s.IsReference() {
+		if n, err = getLength(p); err == nil {
+			n *= len(Reference{})
+			n += 4 // length prefix
+		}
+		return
+	}
 	var l int
 	if l, err = getLength(p); err != nil {
 		return
 	}
 	n += 4
-	if s.IsReference() {
-		n *= len(Reference{})
-		return
-	}
 	el := s.Elem()
 	if s := fixedSize(el.Kind()); s > 0 {
 		n += l * s

--- a/skyobject/value.go
+++ b/skyobject/value.go
@@ -7,6 +7,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
+// Value related errors
 var (
 	ErrInvalidSchemaOrData     = errors.New("invalid schema or data")
 	ErrIndexOutOfRange         = errors.New("index out of range")
@@ -22,6 +23,7 @@ type Value struct {
 	root   *Root  // back reference to related Root
 }
 
+// IsNil retusn true if this Value represents nil
 func (v *Value) IsNil() bool {
 	return v.data == nil
 }
@@ -48,16 +50,19 @@ func (v *Value) Schema() Schema {
 
 // Reference
 
+// Static retursn Reference to obejct
 func (v *Value) Static() (ref Reference, err error) {
 	err = encoder.DeserializeRaw(v.data, &ref)
 	return
 }
 
+// Dynamic returns Dynamic reference to an obejct
 func (v *Value) Dynamic() (dr Dynamic, err error) {
 	err = encoder.DeserializeRaw(v.data, &dr)
 	return
 }
 
+// Dereference a reference
 func (v *Value) Dereference() (val *Value, err error) {
 	switch v.Schema().ReferenceType() {
 	case ReferenceTypeSingle:
@@ -86,7 +91,7 @@ func (v *Value) Dereference() (val *Value, err error) {
 	return
 }
 
-// Length of array, slice or string
+// Len of array, slice or string
 func (v *Value) Len() (l int, err error) {
 	switch v.Kind() {
 	case reflect.Array:
@@ -99,6 +104,7 @@ func (v *Value) Len() (l int, err error) {
 	return
 }
 
+// RangeIndexFunc used to itterate over array or slcie
 type RangeIndexFunc func(i int, val *Value) error
 
 // RangeIndex ranges over arrays and slices. Prefer to use this method
@@ -217,7 +223,7 @@ func (v *Value) Fields() (fs []string) {
 	return
 }
 
-// FieldByName
+// FieldByName returns struct filed by field name
 func (v *Value) FieldByName(name string) (val *Value, err error) {
 	err = v.RangeFields(func(n string, x *Value) error {
 		if n == name {
@@ -232,7 +238,7 @@ func (v *Value) FieldByName(name string) (val *Value, err error) {
 	return
 }
 
-// FieldByIndex
+// FieldByIndex returns struct field by index
 func (v *Value) FieldByIndex(i int) (val *Value, err error) {
 	var j int
 	err = v.RangeFields(func(_ string, x *Value) error {
@@ -249,6 +255,7 @@ func (v *Value) FieldByIndex(i int) (val *Value, err error) {
 	return
 }
 
+// RangeFieldsFunc used to itterate over fields of a struct
 type RangeFieldsFunc func(name string, val *Value) error
 
 // RangeFields iterate over all fields of the Value. Prefer this method
@@ -285,7 +292,7 @@ func (v *Value) RangeFields(rff RangeFieldsFunc) (err error) {
 
 // obtain
 
-// For Int8, Int16, Int32, and Int64
+// Int returns decoded int8, int16, int32, and int64
 func (v *Value) Int() (i int64, err error) {
 	switch v.Kind() {
 	case reflect.Int8:
@@ -308,7 +315,7 @@ func (v *Value) Int() (i int64, err error) {
 	return
 }
 
-// For Uint8, Uint16, Uint32, and Uint64
+// Uint return decoded uint8, uint16, uint32, and uint64
 func (v *Value) Uint() (u uint64, err error) {
 	switch v.Kind() {
 	case reflect.Uint8:
@@ -331,7 +338,7 @@ func (v *Value) Uint() (u uint64, err error) {
 	return
 }
 
-// For float32 and float64
+// Float returns decoded float32 or float64
 func (v *Value) Float() (f float64, err error) {
 	switch v.Kind() {
 	case reflect.Float32:
@@ -346,7 +353,7 @@ func (v *Value) Float() (f float64, err error) {
 	return
 }
 
-// For strings
+// String returns decoded string
 func (v *Value) String() (s string, err error) {
 	if v.Kind() == reflect.String {
 		err = encoder.DeserializeRaw(v.data, &s)
@@ -356,7 +363,7 @@ func (v *Value) String() (s string, err error) {
 	return
 }
 
-// For []byte and string
+// Bytes returns decoded []byte
 func (v *Value) Bytes() (p []byte, err error) {
 	sch := v.Schema()
 	if sch.Kind() == reflect.Slice && sch.Elem().Kind() == reflect.Uint8 {
@@ -373,7 +380,7 @@ func (v *Value) Bytes() (p []byte, err error) {
 	return
 }
 
-// For bool
+// Bool retursn decoded bool
 func (v *Value) Bool() (b bool, err error) {
 	if v.Kind() != reflect.Bool {
 		err = ErrInvalidType
@@ -462,7 +469,7 @@ func schemaArraySize(s Schema, p []byte) (n int, err error) {
 		n = len(Reference{})
 		return
 	}
-	var l int = s.Len()
+	l := s.Len()
 	el := s.Elem()
 	if s := fixedSize(el.Kind()); s > 0 {
 		n = l * s


### PR DESCRIPTION
#### Skyobject

- [x] `(*Root).Inject, InjectMany -> Append`

+ `(*Root).Inject` and `injectMany` has been marked as __deprecated__
+ introduced `(*Root).Append() (drs ...Dynamic)` method
+ introduced `(*Root).Slice(i, j int) (dr []Dynamic, err error)` method
+ introduced `(*Root).Index(i int) (dr Dynamic, err error)` method
+ introduced `(*Root).Len() int` method

So, the changes are for semantics. A `Root` contains slice of references and
methods `Append`, `Index` and `Slice` are intuitive

The `Slice` method returns unsafe slice. But `Refs` method returns
safe copy of references of a `Root`.

#### Node

- [x] move `(*Node).Start()` to `NewNodeReg`

The `(*Node).Start` is deprecated and has been replaced by a stub.

Also

- GC disabled by default

And there is breaking changes:

- `NodeConfig` renamed to `Config` following golang linter recommendations

#### Also

+ added goreportcard, travis-ci and coveralls badges