### PR TITLE
skyobject/ fix Root.WantFunc, add linked list exampel for node

### DIFF
--- a/cmd/cxocli/cxocli_test.go
+++ b/cmd/cxocli/cxocli_test.go
@@ -283,23 +283,24 @@ func Test_tree(t *testing.T) {
 	}
 
 	const want = `(root) %s
-└── struct Group
-    ├── (field) Name
-    │   └── Just an average Group
-    └── (field) Users
-        └── []User
-            ├── *(static) ff1eaf416e8281b398693ce5934af57482493622e4e2978c751e8b12542f04cb
-            │   └── struct User
-            │       ├── (field) Name
-            │       │   └── Bob Simple
-            │       └── (field) Age
-            │           └── 40
-            └── *(static) 915fbaac74e9a55c9ed7050a829d117d8734d0444e3543b8d67557ed9ae813bc
-                └── struct User
-                    ├── (field) Name
-                    │   └── Jim Cobley
-                    └── (field) Age
-                        └── 80
+└── *(dynamic) {49f23bbacc44219be9971cb1e9d70826b3c7eec100c247af82d814255225daf1, 941f946a0ddceaef8aeeee0a8e48ae3579d3cbd18c3de6e0319ced87ab41612a}
+    └── struct Group
+        ├── (field) Name
+        │   └── Just an average Group
+        └── (field) Users
+            └── []User
+                ├── *(static) ff1eaf416e8281b398693ce5934af57482493622e4e2978c751e8b12542f04cb
+                │   └── struct User
+                │       ├── (field) Name
+                │       │   └── Bob Simple
+                │       └── (field) Age
+                │           └── 40
+                └── *(static) 915fbaac74e9a55c9ed7050a829d117d8734d0444e3543b8d67557ed9ae813bc
+                    └── struct User
+                        ├── (field) Name
+                        │   └── Jim Cobley
+                        └── (field) Age
+                            └── 80
 
 `
 

--- a/node/linked_list_example_test.go
+++ b/node/linked_list_example_test.go
@@ -1,0 +1,318 @@
+package node_test
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/cxo/node"
+	"github.com/skycoin/cxo/node/gnet"
+	"github.com/skycoin/cxo/skyobject"
+)
+
+//
+// Linked list: use skyobject.Reference instead of pointer. So,
+// we can't use double-linked-list becasue of back reference
+//
+
+// real linked list
+type any struct {
+	Data string
+	Next *any
+}
+
+var linkedList *any // create the linked-list
+
+// CX linked list
+type Any struct {
+	Data string
+	Next skyobject.Reference `skyobject:"schema=Any"`
+}
+
+func init() {
+	log.SetFlags(log.Lshortfile | log.Ltime)
+}
+
+func fillLinkedList() {
+	linkedList = &any{
+		"one",
+		&any{
+			"two",
+			&any{
+				"three",
+				nil,
+			},
+		},
+	}
+}
+
+func Example_linkedList() {
+
+	// fill linked list
+	fillLinkedList()
+
+	// feed and owner
+
+	feed, owner := cipher.GenerateKeyPair()
+
+	// launch src->pipe->dst
+
+	pipe, err := PipeNodeLinkedList(feed)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+	defer pipe.Close()
+
+	src, err := SourceNodeLinkedList(feed, owner, pipe.Pool().Address())
+	if err != nil {
+		log.Print(err)
+		return
+	}
+	defer src.Close()
+
+	dst, err := DestinationNodeLinkedList(feed, pipe.Pool().Address())
+	if err != nil {
+		log.Print(err)
+		return
+	}
+	defer dst.Close()
+
+	select {
+	case <-src.Quiting():
+	case <-pipe.Quiting():
+	case <-dst.Quiting():
+	}
+
+}
+
+func PipeNodeLinkedList(feed cipher.PubKey) (pipe *node.Node, err error) {
+	conf := node.NewConfig()
+	conf.Listen = "127.0.0.1:0" // arbitrary assignment (for example)
+	conf.InMemoryDB = true      // use in-memory database (for example)
+	conf.EnableRPC = false      // disable RPC (for example)
+	conf.Log.Prefix = "[PIPE] "
+	// conf.Log.Debug = true
+
+	// node
+	if pipe, err = node.NewNode(conf); err != nil {
+		return
+	}
+
+	// feed
+	pipe.Subscribe(nil, feed)
+
+	return
+}
+
+func SourceNodeLinkedList(feed cipher.PubKey, owner cipher.SecKey,
+	address string) (src *node.Node, err error) {
+
+	// create registry and register all types we are going to use
+	reg := skyobject.NewRegistry()
+	reg.Register("Any", Any{})
+
+	// config
+
+	conf := node.NewConfig()
+	conf.EnableListener = false // don't listen (for example)
+	conf.InMemoryDB = true      // use in-memory database (for example)
+	conf.EnableRPC = false      // disable RPC (for example)
+	conf.Log.Prefix = "[SRC] "
+	// conf.Log.Debug = true
+
+	// node
+	if src, err = node.NewNodeReg(conf, reg); err != nil {
+		return
+	}
+
+	// dial to pipe
+	var pc *gnet.Conn
+	pc, err = src.Pool().Dial(address)
+	if err != nil {
+		src.Close()
+		log.Print(err)
+		return
+	}
+
+	// subscribe to pipe+feed and make the pipe
+	// subscribed to the feed of the src
+	if err = src.SubscribeResponse(pc, feed); err != nil {
+		src.Close()
+		log.Print(err)
+		return
+	}
+
+	// don't block
+
+	go generateLinkedList(src, feed, owner)
+
+	return
+
+}
+
+func generateLinkedList(src *node.Node, feed cipher.PubKey,
+	owner cipher.SecKey) {
+
+	defer src.Close()
+
+	// for this example (never need in real case)
+	time.Sleep(1 * time.Second)
+
+	// container will push all updates to subscribed peers (to the Pipe)
+	cnt := src.Container()
+
+	// root object that refers to our registry and
+	// we will attach the linked list to the root
+	root, err := cnt.NewRoot(feed, owner)
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	shareLinkedList(cnt, root)
+
+	// for this example (waiting for replication)
+	time.Sleep(1 * time.Second)
+}
+
+func shareLinkedList(cnt *node.Container, root *node.Root) {
+
+	// actually, GC disabled by default and we don't need the LockGC / UnlockGC
+	cnt.LockGC()
+	defer cnt.UnlockGC()
+
+	// find a tail of the list
+	var chain []*any
+
+	for elem := linkedList; elem != nil; elem = elem.Next {
+		chain = append(chain, elem)
+	}
+
+	// save elements of the list from tail
+	var a *any
+	var prev skyobject.Reference
+	for i := len(chain) - 1; i >= 0; i-- {
+		a = chain[i]
+		prev = root.Save(Any{
+			Data: a.Data,
+			Next: prev,
+		})
+	}
+
+	// now the prev contains first element of the list;
+	// let's attach it to root
+
+	// we can attach to Root Dynamic reference only
+
+	sch, err := root.SchemaReferenceByName("Any")
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	first := skyobject.Dynamic{
+		Schema: sch,  // schema reference
+		Object: prev, // object reference
+	}
+
+	if _, err := root.Append(first); err != nil {
+		log.Print(err)
+	}
+
+	// this way, the root points to registry and first element of te list,
+	// first element knows what shcema of next element (skyobject struct tag)
+	// and the first element points to next, and so on
+
+}
+
+func DestinationNodeLinkedList(feed cipher.PubKey,
+	address string) (dst *node.Node, err error) {
+
+	// config
+
+	conf := node.NewConfig()
+	conf.EnableListener = false // disable listener for this example
+	conf.InMemoryDB = true      // use database in memory
+	conf.EnableRPC = false
+	conf.Log.Prefix = "[DST] "
+	// conf.Log.Debug = true
+
+	// while a root object and all related objects received
+	conf.OnRootFilled = func(root *node.Root) {
+		// don't block messages handling;
+		// it's not nessesary for this example, but
+		// if you want to perform a long running
+		// task in this callback, then you need
+		// to keep in mind that this callback
+		// blocks goroutine that handles incoming
+		// messages from this connection
+		go printTreeLinkedList(root)
+	}
+
+	// node
+
+	dst, err = node.NewNode(conf)
+	if err != nil {
+		return
+	}
+
+	var src *gnet.Conn
+
+	if src, err = dst.Pool().Dial(address); err != nil {
+		log.Print(err)
+		dst.Close()
+		return
+	}
+
+	if err = dst.SubscribeResponse(src, feed); err != nil {
+		log.Print(err)
+		dst.Close()
+		return
+	}
+
+	return
+
+}
+
+func printTreeLinkedList(root *node.Root) {
+
+	fmt.Println("----")
+	defer fmt.Println("----")
+
+	fmt.Println(root.Inspect())
+}
+
+/*
+
+Output:
+--------------------------------------------------------------------------------
+[PIPE] 00:43:37 node.go:284: listen on 127.0.0.1:37205
+----
+(root) 41d87baf46f73ba78c5a857f6a2696e82eb8602a8e6a715091af67913f8cd1d3
+└── *(dynamic) {e936b0757713505f4a29fa6e33d5d7c474eef2c2f334b81619c64dd9b96af614, 4c87cc858135b5735934137b43b05921a36e85eb1ec1832d4785d9cd9bb0e461}
+    └── struct Any
+        ├── (field) Data
+        │   └── one
+        └── (field) Next
+            └── *(static) 2c9f6080e1112d909ca3e4c5e08e22baf91933b41d22eec58d68e9ee77dc973a
+                └── struct Any
+                    ├── (field) Data
+                    │   └── two
+                    └── (field) Next
+                        └── *(static) 57f57aac0390f14afc4287ca8f10abb6296b542d50fd8698012cd839a5f76a87
+                            └── struct Any
+                                ├── (field) Data
+                                │   └── three
+                                └── (field) Next
+                                    └── *(static) 0000000000000000000000000000000000000000000000000000000000000000
+                                        └── nil
+
+----
+[PIPE] 00:43:39 conn.go:474: [ERR] 127.0.0.1:48326 reading error: EOF
+[PIPE] 00:43:39 conn.go:474: [ERR] 127.0.0.1:48328 reading error: EOF
+--------------------------------------------------------------------------------
+
+*/

--- a/skyobject/inspect.go
+++ b/skyobject/inspect.go
@@ -24,15 +24,16 @@ func (r *Root) Inspect() (tree string) {
 }
 
 func rootItems(root *Root) (items []gotree.GTStructure) {
-	vals, err := root.Values()
-	if err != nil {
-		items = []gotree.GTStructure{
-			{Name: "error: " + err.Error()},
+	for _, dr := range root.Refs() {
+		item := gotree.GTStructure{Name: "*(dynamic) " + dr.String()}
+		if dr.IsBlank() {
+			item.Items = []gotree.GTStructure{{"nil", nil}}
+		} else if val, err := root.ValueByDynamic(dr); err != nil {
+			item.Items = []gotree.GTStructure{{Name: "error: " + err.Error()}}
+		} else {
+			item.Items = []gotree.GTStructure{valueItem(val)}
 		}
-		return
-	}
-	for _, val := range vals {
-		items = append(items, valueItem(val))
+		items = append(items, item)
 	}
 	return
 }

--- a/skyobject/root.go
+++ b/skyobject/root.go
@@ -585,6 +585,9 @@ func (r *Root) wantFunc(wf WantFunc) (err error) {
 }
 
 func wantValue(v *Value) (err error) {
+	if v.IsNil() {
+		return
+	}
 	switch v.Kind() {
 	case reflect.Slice, reflect.Array:
 		err = v.RangeIndex(func(_ int, d *Value) error {

--- a/skyobject/value_test.go
+++ b/skyobject/value_test.go
@@ -1,0 +1,53 @@
+package skyobject
+
+import (
+	"testing"
+
+	"github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/cxo/data"
+)
+
+func testValueDereferenceNil(t *testing.T) {
+	//
+}
+
+func TestValue_Derefernece(t *testing.T) {
+
+	type Single struct {
+		Ref Reference `skyobject:"schema=Single"`
+	}
+
+	type Array struct {
+		Refs References `skyobject:"schema=Single"`
+	}
+
+	reg := NewRegistry()
+	reg.Register("Single", Single{})
+	reg.Register("Array", Array{})
+
+	c := NewContainer(data.NewMemoryDB(), reg)
+
+	pk, sk := cipher.GenerateKeyPair()
+
+	root, err := c.NewRoot(pk, sk)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = root // TODO
+
+	t.Run("invalid type", func(t *testing.T) {
+		// val := &Value{root}- // TODO
+	})
+
+	t.Run("static", func(t *testing.T) {
+		// TODO
+	})
+
+	t.Run("dynamic", func(t *testing.T) {
+		// TODO
+	})
+
+}


### PR DESCRIPTION
#### Skyobejct

+ fix `Root.WantFunc` bug related to blank references
+ add necessary tests
+ improve `Root.Inspect` method. The Inspect prints root Dynamic references too, e.g.
```
(root) 88afc3aa3a964be04f58c32e85d29bf81c075181284bd28fb6e412f16b878b94
└── *(dynamic) {49f23bbacc44219be9971cb1e9d70826b3c7eec100c247af82d814255225daf1, 941f946a0ddceaef8aeeee0a8e48ae3579d3cbd18c3de6e0319ced87ab41612a}
    └── struct Group
         └── (field) Name
             └── Just an average Group
```
instead of (previous behavior)
```
(root) 88afc3aa3a964be04f58c32e85d29bf81c075181284bd28fb6e412f16b878b94
└── struct Group
     └── (field) Name
         └── Just an average Group
```

#### Node

+ add linked-list example
