### PR TITLE
New syntax errors fixed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ CONTRIBUTING
   `IsExist()`, etc
 - tests, examples and benchmarks should follow Golang naming convention
 
-More then that you should check you code with:
+More than that you should check your code with:
 
 - `go vet` (`go vet ./...`)
 - [`gocyclo`](https://github.com/fzipp/gocyclo) (`gocyclo -over 15 .`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 CONTRIBUTING
 ============
 
-- all `.go` souce files should be formated with `-s` flag
+- all `.go` source files should be formated with `-s` flag
 - length of a code line must not exceed 80 characters
 - follow Golang naming convention: CamelCase, `Value()/SetValue()`,
   `IsExist()`, etc
-- tests, examples and benchmarks should follow Golagn naming convention
+- tests, examples and benchmarks should follow Golang naming convention
 
 More then that you should check you code with:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [CXO wiki](https://github.com/skycoin/cxo/wiki) to get this information
 ### Installation and Version
 
 Use [dep](https://github.com/golang/dep) to use particular version of the
-CXO. The maser branch of the repository points to latest stable release.
+CXO. The master branch of the repository points to latest stable release.
 Actually, it points to alpha-release for now.
 
 To get the release use

--- a/cmd/cxod/README.md
+++ b/cmd/cxod/README.md
@@ -1,5 +1,5 @@
 CXO Daemon
 ==========
 
-The cxod is daemon for CX objects. This daemon accpts all incoming
+The cxod is daemon for CX objects. This daemon accepts all incoming
 connections and subscription.

--- a/skyobject/CHANGELOG.md
+++ b/skyobject/CHANGELOG.md
@@ -1,4 +1,4 @@
 changes
 =======
 
-refacoted
+refactored

--- a/skyobject/README.md
+++ b/skyobject/README.md
@@ -3,7 +3,7 @@ skyobject
 
 [![GoDoc](https://godoc.org/github.com/skycoin/cxo/skyobject?status.svg)](https://godoc.org/github.com/skycoin/cxo/skyobject)
 
-Skobject represents CX objects tree.
+Skyobject represents CX objects tree.
 
 See [wiki](https://godoc.org/github.com/skycoin/cxo/wiki/Skyobject)
 


### PR DESCRIPTION
Files that has syntax errors are in the following files:
  * Root directory:
     - README.md file
     - CONTRIBUTING.md file

  * Skyobject directory
     - README.md file
     - CHANGELOG.md file
 
  * cxod directory 
    - README.md file