### PR TITLE
replaced first line at build.sh

### DIFF
--- a/cmd/cxodbfix/build.sh
+++ b/cmd/cxodbfix/build.sh
@@ -1,4 +1,4 @@
-#!/bin/evn bash
+#!/usr/bin/env bash
 
 # $1 - os
 # $2 - arch


### PR DESCRIPTION
Replaced `#!/bin/evn bash` with `#!/usr/bin/env bash` to avoid wrong interpreter error

Signed-off-by: Leonardo Javier Esparis Meza <ljesparis@gmail.com>